### PR TITLE
create seed data for sensor types

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Make sure you have ruby version 2.3.1 installed on your system.
     bin/rake db:migrate
     ```
 
+4. Seed the database
+    ```
+    bin/rake db:seed
+    ```
+
 ## Usage
 
 Start the app with:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,25 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+#
+
+
+
+attribute_hashes = [
+  { :property =>"Temperature", :unit => "°C" },
+  { :property =>"Atmospheric Pressure", :unit => "Bar" },
+  { :property =>"Motion", :unit => "0-10" },
+  { :property =>"Brightness", :unit => "0-10" },
+  { :property =>"Volume", :unit => "0-10" },
+  { :property =>"Humidity", :unit => "%" },
+  { :property =>"Button", :unit => "On/Off" },
+  { :property =>"Geophone", :unit => "?...?" },
+  { :property =>"Gas: Methan", :unit => "%" },
+  { :property =>"Gas: Alcohol", :unit => "%" },
+  { :property =>"Gas: Ozone", :unit => "%" },
+  { :property =>"Air quality", :unit => "?...?" },
+  { :property =>"Vibration", :unit => "0-10" },
+  { :property =>"Relative Humidity" , :unit => "%" },
+]
+
+attribute_hashes.each  { |attributes| SensorType.create attributes }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,20 +10,20 @@
 
 
 attribute_hashes = [
-  { :property =>"Temperature", :unit => "°C" },
-  { :property =>"Atmospheric Pressure", :unit => "Bar" },
-  { :property =>"Motion", :unit => "0-10" },
-  { :property =>"Brightness", :unit => "0-10" },
-  { :property =>"Volume", :unit => "0-10" },
-  { :property =>"Humidity", :unit => "%" },
-  { :property =>"Button", :unit => "On/Off" },
-  { :property =>"Geophone", :unit => "?...?" },
-  { :property =>"Gas: Methan", :unit => "%" },
-  { :property =>"Gas: Alcohol", :unit => "%" },
-  { :property =>"Gas: Ozone", :unit => "%" },
-  { :property =>"Air quality", :unit => "?...?" },
-  { :property =>"Vibration", :unit => "0-10" },
-  { :property =>"Relative Humidity" , :unit => "%" },
+  { :property => "Temperature",          :unit => "°C"     } ,
+  { :property => "Atmospheric Pressure", :unit => "Bar"    } ,
+  { :property => "Motion",               :unit => "0-10"   } ,
+  { :property => "Brightness",           :unit => "0-10"   } ,
+  { :property => "Volume",               :unit => "0-10"   } ,
+  { :property => "Humidity",             :unit => "%"      } ,
+  { :property => "Button",               :unit => "On/Off" } ,
+  { :property => "Geophone",             :unit => "?...?"  } ,
+  { :property => "Gas: Methan",          :unit => "%"      } ,
+  { :property => "Gas: Alcohol",         :unit => "%"      } ,
+  { :property => "Gas: Ozone",           :unit => "%"      } ,
+  { :property => "Air quality",          :unit => "?...?"  } ,
+  { :property => "Vibration",            :unit => "0-10"   } ,
+  { :property => "Relative Humidity" ,   :unit => "%"      } ,
 ]
 
 attribute_hashes.each  { |attributes| SensorType.create attributes }


### PR DESCRIPTION
fix: #32 
@drjakob I haven't abbreviated the sensor type properties. We can still add a new attribute if necessary. Or anything else, that is common to all sensors of a certain class or type.