### PR TITLE
82 set report name

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -45,6 +45,6 @@ class ReportsController < ApplicationController
   private
 
   def report_params
-    params.require(:report).permit(:start_date, :video)
+    params.require(:report).permit(:name, :start_date, :video)
   end
 end

--- a/app/views/reports/_form.html.haml
+++ b/app/views/reports/_form.html.haml
@@ -1,4 +1,5 @@
 = simple_form_for @report do |f|
+  = f.input :name
   = f.input :start_date
   = f.input :video, label: "Video URL"
   = f.button :submit

--- a/features/reports/report_settings_page.feature
+++ b/features/reports/report_settings_page.feature
@@ -3,12 +3,21 @@ Feature: Report Settings page
   I want to have a settings page for my live report
   To change settings regarding the whole experiment, e.g. start date, publishing, social media
 
-  Scenario:
+  Background:
     Given I am the journalist
     And my current live report is called "Me Wired"
     When I visit the landing page
     And I select "Me Wired" from the settings in my dashboard
     And I click on "Edit"
-    And I choose "15 June 2016" to be the start date for the experiment
+
+  @25
+  Scenario: Set the start date of the experiment
+    When I choose "15 June 2016" to be the start date for the experiment
     And I click on update
     Then the live report about "Me Wired" will start on that date
+
+  @82 @wip
+  Scenario: Set the start date of the experiment
+    When I change the name of the report to "Very good report"
+    And I click on update
+    Then I see the new name in the settings menu above

--- a/features/reports/report_settings_page.feature
+++ b/features/reports/report_settings_page.feature
@@ -16,7 +16,7 @@ Feature: Report Settings page
     And I click on update
     Then the live report about "Me Wired" will start on that date
 
-  @82 @wip
+  @82
   Scenario: Set the start date of the experiment
     When I change the name of the report to "Very good report"
     And I click on update

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -338,4 +338,12 @@ When(/^the application archives the current report$/) do
   Rake::Task[task].invoke
 end
 
+When(/^I change the name of the report to "([^"]*)"$/) do |name|
+  @report_name = name
+  fill_in 'Name', with: @report_name
+end
 
+Then(/^I see the new name in the settings menu above$/) do
+  expect(page).to have_css('.dropdown-menu')
+  expect(find('.dropdown-menu')).to have_text @report_name
+end


### PR DESCRIPTION
@drjakob I have a question: #82 explains that the "Cow name" should be set for later use in the report. This PR allows to change the `report name`. E.g. from "Kuh Bertha" to "Kuh Sieglinde". Is this enough to fulfill the requirement? Or to be more precise, shall we use the name of the report in the generated text?