### PR TITLE
add migration that creates default channels

### DIFF
--- a/db/migrate/20170402092445_create_default_channels.rb
+++ b/db/migrate/20170402092445_create_default_channels.rb
@@ -1,0 +1,22 @@
+class CreateDefaultChannels < ActiveRecord::Migration[5.0]
+  class Channel < ActiveRecord::Base
+    belongs_to :report
+  end
+
+  class Report < ActiveRecord::Base
+  end
+
+  def change
+    # make sure at least one report is there
+    Report.find_or_create_by(name: 'Kuh Bertha') do |r|
+      r.start_date = Time.now
+    end
+
+    # for every report, create default channels
+    Report.find_each do |report|
+      ["sensorstory", "chatbot"].each do |channel_name|
+        Channel.find_or_create_by(name: channel_name, report: report)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170331165247) do
+ActiveRecord::Schema.define(version: 20170402092445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,7 @@ Report.find_each do |report|
     c.description = "Default Channel"
   end
 
-  chatbot_channel = Channel.find_or_create_by(
+  Channel.find_or_create_by(
     report: report,
     name: "chatbot"
   ) do |c|


### PR DESCRIPTION
Leave Factories in place, because in testing the database is often reset, so default channels won't be there at all

fixes #297