### PR TITLE
Use static data in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - cp config/database.travis.yml config/database.yml
+  - bundle exec rake db:create db:migrate
 
 script: xvfb-run -a bundle exec rake
 

--- a/app/models/channel.rb
+++ b/app/models/channel.rb
@@ -6,6 +6,7 @@ class Channel < ActiveRecord::Base
   scope :sensorstory, -> { find_by(report: Report.current, name: "sensorstory") }
 
   validates :report, presence: true
+  validates :name, presence: true, uniqueness: true
 
   def self.default(report)
     Channel.sensorstory

--- a/db/migrate/20170402092445_create_default_channels.rb
+++ b/db/migrate/20170402092445_create_default_channels.rb
@@ -8,8 +8,8 @@ class CreateDefaultChannels < ActiveRecord::Migration[5.0]
 
   def change
     # make sure at least one report is there
-    Report.find_or_create_by(name: 'Kuh Bertha') do |r|
-      r.start_date = Time.now
+    unless Report.first
+      Report.create!(name: 'Kuh Bertha', start_date: Time.now)
     end
 
     # for every report, create default channels

--- a/db/migrate/20170419204307_add_unique_constraint_to_channel.rb
+++ b/db/migrate/20170419204307_add_unique_constraint_to_channel.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToChannel < ActiveRecord::Migration[5.0]
+  def change
+    add_index :channels, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170402092445) do
+ActiveRecord::Schema.define(version: 20170419204307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 20170402092445) do
     t.integer  "report_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["name"], name: "index_channels_on_name", unique: true, using: :btree
     t.index ["report_id"], name: "index_channels_on_report_id", using: :btree
   end
 

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -154,7 +154,8 @@ Given(/^I am the journalist$/) do
 end
 
 Given(/^there is a sensor live report/) do
-  create(:channel, name: "sensorstory") # report will be implicitly created
+  expect(Report.current).to be_present
+  expect(Channel.sensorstory).to be_present
 end
 
 Given(/^I visit the settings page of the current report$/) do
@@ -184,7 +185,9 @@ Then(/^the live report about "([^"]*)" will start on that date$/) do |name|
 end
 
 Given(/^my current live report is called "([^"]*)"$/) do |name|
-  default_channel = create(:channel, name: "sensorstory", report: create(:report, name: name))
+  report = Report.current
+  report.name = name
+  report.save
 end
 
 When(/^I select "([^"]*)" from the settings in my dashboard$/) do |name|
@@ -373,8 +376,7 @@ Then(/^I see the new name in the settings menu above$/) do
 end
 
 Given(/^there is a triggered text component with the following main part:$/) do |main_part|
-  channel = create(:channel, name: "sensorstory")
-  create(:text_component, main_part: main_part, report: channel.report, channels: [channel])
+  create(:text_component, main_part: main_part, report: Report.current)
 end
 
 Given(/^I have these active triggers:$/) do |table|
@@ -733,7 +735,10 @@ When(/^I update the text component$/) do
 end
 
 Given(/^our sensor live report has a channel "([^"]*)"$/) do |name|
-  @channel = create(:channel, name: name, report: Report.current)
+  @channel =  Channel.find_by(name: name)
+  unless @channel
+    @channel = create(:channel, name: name, report: Report.current)
+  end
 end
 
 Given(/^a topic "([^"]*)"$/) do |name|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -64,7 +64,7 @@ end
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
-Cucumber::Rails::Database.javascript_strategy = :truncation
+Cucumber::Rails::Database.javascript_strategy = :transaction
 
 
 

--- a/spec/controllers/channels_controller_spec.rb
+++ b/spec/controllers/channels_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe ChannelsController, type: :controller do
   end
 
   describe 'GET #edit' do
-    let(:report) { create(:report) }
-    let!(:channel) { create(:channel, name: "sensorstory", report: report) }
+    let(:report) { Report.current }
+    let(:channel) { Channel.sensorstory }
 
     it 'renders correct template' do
       get :edit, params: {id: channel.id, report_id: report.id}, session: valid_session

--- a/spec/controllers/chatfuel_controller_spec.rb
+++ b/spec/controllers/chatfuel_controller_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe ChatfuelController, type: :controller do
   let(:valid_session) { {} }
 
-  let!(:chatbot_channel)   { create :channel, report: report, name: "chatbot" }
-  let(:report)            { create(:report) }
+  let(:chatbot_channel)   { Channel.chatbot }
+  let(:report)            { Report.current }
   let(:topic_name)        { "milk_quality" }
   let(:topic)             { create(:topic, name: topic_name) }
 
@@ -17,7 +17,7 @@ RSpec.describe ChatfuelController, type: :controller do
 
   context "matching text component" do
     let(:main_part) { "Main Part" }
-    let!(:text_component) do
+    let(:text_component) do
       create(
         :text_component,
         report: report,
@@ -26,6 +26,8 @@ RSpec.describe ChatfuelController, type: :controller do
         main_part: main_part
       )
     end
+
+    before { text_component }
 
     it "returns expected text" do
       get :show, params: {topic: topic_name}, session: valid_session

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -1,17 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe ReportsController, type: :controller do
-  let(:sensorstory_channel)  { create(:channel, name: "sensorstory") }
 
   describe 'GET #current' do
     it 'redirects to current report' do
-      create(:report, id: 1, channels: [sensorstory_channel])
+      expect(Report.current.id).to eq 1
       get :current
       expect(response).to redirect_to '/reports/present/1'
     end
 
     context 'no reports' do
       it 'renders a replacement template' do
+        Report.destroy_all
         get :current
         expect(response).to render_template :no_reports
       end
@@ -20,7 +20,7 @@ RSpec.describe ReportsController, type: :controller do
 
   describe 'GET #present' do
     it "renders template 'present'" do
-      create(:report, id: 1, channels: [sensorstory_channel])
+      expect(Report.current.id).to eq 1
       get :present, params: {id: 1}
       expect(response).to render_template :present
     end

--- a/spec/factories/channels.rb
+++ b/spec/factories/channels.rb
@@ -1,11 +1,6 @@
 FactoryGirl.define do
   factory :channel do
-    name "sensorstory"
-
-    initialize_with do
-      Channel.find_or_create_by(name: name) do |c|
-        c.report = build(:report)
-      end
-    end
+    name 'JustAnotherChannel'
+    association :report
   end
 end

--- a/spec/factories/text_components.rb
+++ b/spec/factories/text_components.rb
@@ -9,7 +9,7 @@ FactoryGirl.define do
 
     association :report
 
-    channels { create_list(:channel, 1) }
+    channels { [Channel.sensorstory] }
 
     trait :active do
       # active by default

--- a/spec/jobs/whenever_spec.rb
+++ b/spec/jobs/whenever_spec.rb
@@ -13,7 +13,7 @@ describe 'Whenever Schedule' do
 
   context 'with a report' do
     before do
-      create :channel, name: "sensorstory" # Report will be implicitly created
+      expect(Report.current).to be_present
     end
 
     it 'creates records' do

--- a/spec/models/channel_spec.rb
+++ b/spec/models/channel_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'support/shared_examples/database_unique_attribute'
 
 RSpec.describe Channel, type: :model do
   describe 'factory' do
@@ -9,5 +10,9 @@ RSpec.describe Channel, type: :model do
   describe 'channel without report' do
     subject { build(:channel, report: nil) }
     it { is_expected.not_to be_valid }
+  end
+
+  describe '#name' do
+    it_behaves_like 'database unique attribute', :channel, name: 'TheChannel'
   end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Report, type: :model do
-  let!(:sensorstory_channel)   { create(:channel, name: "sensorstory", report: report) }
   let(:report) { create(:report) }
-  context 'given a report' do
-    before { report }
-    specify { expect(Report.current).to eql report }
+
+  describe '#current' do
+    specify { expect(Report.current).to be_present }
   end
 
   describe '#destroy' do

--- a/spec/models/text_component_spec.rb
+++ b/spec/models/text_component_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe TextComponent, type: :model do
 
   describe '#create' do
     let(:report) { create(:report) }
-    let!(:default_channel) { create(:channel, name: "sensorstory", report: report) }
     subject { create(:text_component, report: report) }
 
     it "has a channel assigned" do

--- a/spec/text/generator_spec.rb
+++ b/spec/text/generator_spec.rb
@@ -1,13 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Text::Generator do
-  let!(:sensorstory_channel)  { create(:channel, name: "sensorstory", report: report) }
-  let(:report)                { create(:report) }
+  let(:report)                { Report.current }
   let(:intention)             { :real }
   subject { described_class.new(report: report, opts: {intention: intention}) }
 
   context 'for text components with the same report and the same channel' do
-    let(:text_component_params) { { report: report, channels: [sensorstory_channel] } }
+    let(:text_component_params) { { report: report } }
 
     describe '#choose_heading' do
       subject { super().choose_heading }


### PR DESCRIPTION
@matthib you are already familiar with issues of static data

This does not change anything from the user perspective. It makes sure that no channels and no reports will be created in tests unless it is explicitly asked for. We have a migration for static data so we assume static data to be accessible in our tests. As another sanity check this introduces a unique constraint on the channels, so we don't create channels with the same name by accident.