### PR TITLE
Chatfuel questions and answers

### DIFF
--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -2,88 +2,63 @@ class ChatfuelController < ApplicationController
   def show
     chatbot_channel = Channel.chatbot
 
-    tc = Text::Sorter.sort(chatbot_channel.text_components, {}).first
+    @text_component = Text::Sorter.sort(chatbot_channel.text_components, {}).first
 
-    if tc
-      text = Text::Renderer.new(text_component: tc).render(:main_part)
-
-      qa = tc.question_answers
-
-      #Test API Request: http://localhost:3000/chatfuel/1
-      if qa.exists?(1)
-          sendJsonResponse(text, 1, qa.find(1).question)
-      else
-          sendJsonResponse(text)
-      end
-
+    if @text_component
+      @next_question_answer = @text_component.question_answers.first
+      render json: json_response
     else
-     render json: {}, status: 404
+      render json: {}, status: 404
     end
   end
 
-  def showQuestionAndAnswer
-      # request for qa for a specific text component
-      # send answer as json response to chatfuel
-      # if more questions and answers available, append button for next answer to json response
-
-      chatbot_channel = Channel.chatbot
-
-      tc = Text::Sorter.sort(chatbot_channel.text_components, {}).first
-
-      if tc
-          qaId = params[:id]
-
-          if tc.question_answers.exists?(qaId)
-              qa = tc.question_answers.find(qaId)
-
-              if tc.question_answers.exists?(qaId.to_i + 1)
-                  # send answer + button for next question
-                  sendJsonResponse(qa.answer, qaId.to_i + 1, tc.question_answers.find(qaId.to_i + 1).question)
-              else
-                  # send only answer for this question
-                  sendJsonResponse(qa.answer)
-              end
-          else
-              render json: {}, status: 404
-          end
-
-      else
-          render json: {}, status: 404
-      end
+  def answer_to_question
+    @text_component = TextComponent.includes(:question_answers).find(params[:text_component_id])
+    index = params[:index].to_i
+    @question_answer = @text_component.question_answers[index]
+    @next_question_answer = nil # TODO: implement
+    render json: json_response
   end
 
-  def sendJsonResponse(text, qaId = 0, questionText = '')
-      if qaId.to_i == 0
-          @response = {
-            messages: [
-              { text: text.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
-            ]
-          }
-      else
-          # send json response with text + qa button
-          # todo: create url for next question from question id
-          @response = {
-              "messages": [
-                  {
-                    "attachment": {
-                      "type": "template",
-                      "payload": {
-                        "template_type": "button",
-                        "text": text.first(640),
-                        "buttons": [
-                          {
-                            "type": "web_url",
-                            "url": chatfuel_qa_url(params[:topic], qaId), #'test',  #generate url for next question
-                            "title": questionText.first(640) #question
-                          }
-                        ]
-                      }
-                    }
-                  }
-                ]
-          }
-      end
+  private
 
-      render json: @response
+  def json_response
+    if @text_component
+      text = Text::Renderer.new(text_component: @text_component).render(:main_part)
+      messages =  [
+        { text: text.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
+      ]
+    end
+
+    if @question_answer
+      messages << {
+        text: @question_answer.answer
+      }
+    end
+
+    if @next_question_answer
+      messages <<  {
+        attachment: {
+          payload: {
+            template_type: "button",
+            text: "I have actually no idea how Chatfuel renders this part. Is it some text up front to the button?",
+            buttons: [
+              {
+                url: answer_to_question_url(text_component_id: @text_component, index: @text_components.question_answers.index(@next_question_answer)),
+                type: "json_plugin_url",
+                title: @next_question_answer.question
+              }
+          ]
+          },
+          type: "template"
+        }
+      }
+    end
+
+    # return this hash
+    {
+      messages: messages
+    }
+
   end
 end

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -27,19 +27,11 @@ class ChatfuelController < ApplicationController
   private
 
   def json_response
-    if @text_component
-      text = Text::Renderer.new(text_component: @text_component).render(:main_part)
-      messages =  [
-        { text: text.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
-      ]
-      @content = text.first(640);
-    end
-
     if @question_answer
-      messages =  [
-        { text: @question_answer.answer }
-      ]
-      @content = @question_answer.answer;
+      content = @question_answer.answer
+    else
+      text = Text::Renderer.new(text_component: @text_component).render(:main_part)
+      content = text.first(640);
     end
 
     if @next_question_answer
@@ -48,7 +40,7 @@ class ChatfuelController < ApplicationController
           attachment: {
             payload: {
               template_type: "button",
-              text: "#{@content}",
+              text: "#{content}",
               buttons: [
                 {
                   url: answer_to_question_url(text_component_id: @text_component, index: @text_component.question_answers.index(@next_question_answer) + 1),
@@ -60,6 +52,10 @@ class ChatfuelController < ApplicationController
             type: "template"
           }
         }
+      ]
+    else
+      messages =  [
+        { text: content.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
       ]
     end
 

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -44,7 +44,7 @@ class ChatfuelController < ApplicationController
             text: "I have actually no idea how Chatfuel renders this part. Is it some text up front to the button?",
             buttons: [
               {
-                url: answer_to_question_url(text_component_id: @text_component, index: @text_components.question_answers.index(@next_question_answer)),
+                url: answer_to_question_url(text_component_id: @text_component, index: @text_component.question_answers.index(@next_question_answer)),
                 type: "json_plugin_url",
                 title: @next_question_answer.question
               }

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -16,8 +16,12 @@ class ChatfuelController < ApplicationController
     @text_component = TextComponent.includes(:question_answers).find(params[:text_component_id])
     index = params[:index].to_i - 1
     @question_answer = @text_component.question_answers[index]
-    @next_question_answer = @text_component.question_answers[index + 1]
-    render json: json_response
+    if @question_answer
+      @next_question_answer = @text_component.question_answers[index + 1]
+      render json: json_response
+    else
+      render json: {}, status: 404
+    end
   end
 
   private

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -17,4 +17,70 @@ class ChatfuelController < ApplicationController
       render json: {}, status: 404
     end
   end
+
+  def showQuestionAndAnswer
+      # request for qa for a specific text component
+      # send answer as json response to chatfuel
+      # if more questions and answers available, append button for next answer to json response
+
+      chatbot_channel = Channel.chatbot
+
+      tc = Text::Sorter.sort(chatbot_channel.text_components, {}).first
+
+      if tc
+          qaId = params[:id]
+
+          if tc.question_answers.exists?(qaId)
+              qa = tc.question_answers.find(qaId)
+
+              if tc.question_answers.exists?(qaId.to_i + 1)
+                  # send answer + button for next question
+                  sendJsonResponse(qa.answer, qaId)
+              else
+                  # send only answer for this question
+                  sendJsonResponse(qa.answer, qaId.to_i + 1)
+              end
+          else
+              render json: {}, status: 404
+          end
+
+      else
+          render json: {}, status: 404
+      end
+  end
+
+  def sendJsonResponse(text, qaId)
+      if !qaId
+          @response = {
+            messages: [
+              { text: text.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
+            ]
+          }
+      else
+          # send json response with text + qa button
+          # todo: create url for next question from question id
+          @response = {
+              "messages": [
+                  {
+                    "attachment": {
+                      "type": "template",
+                      "payload": {
+                        "template_type": "button",
+                        "text": text.first(640),
+                        "buttons": [
+                          {
+                            "type": "web_url",
+                            "url": "https://petersapparel.parseapp.com/buy_item?item_id=100",
+                            "title": "Buy Item"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+          }
+      end
+
+      render json: @response
+  end
 end

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -10,7 +10,7 @@ class ChatfuelController < ApplicationController
       qa = tc.question_answers
 
       #Test API Request: http://localhost:3000/chatfuel/1
-      if qa
+      if qa.exists?(1)
           sendJsonResponse(text, 1, qa.find(1).question)
       else
           sendJsonResponse(text)

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -14,9 +14,9 @@ class ChatfuelController < ApplicationController
 
   def answer_to_question
     @text_component = TextComponent.includes(:question_answers).find(params[:text_component_id])
-    index = params[:index].to_i
+    index = params[:index].to_i - 1
     @question_answer = @text_component.question_answers[index]
-    @next_question_answer = nil # TODO: implement
+    @next_question_answer = @text_component.question_answers[index + 1]
     render json: json_response
   end
 
@@ -28,31 +28,35 @@ class ChatfuelController < ApplicationController
       messages =  [
         { text: text.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
       ]
+      @content = text.first(640);
     end
 
     if @question_answer
-      messages << {
-        text: @question_answer.answer
-      }
+      messages =  [
+        { text: @question_answer.answer }
+      ]
+      @content = @question_answer.answer;
     end
 
     if @next_question_answer
-      messages <<  {
-        attachment: {
-          payload: {
-            template_type: "button",
-            text: "I have actually no idea how Chatfuel renders this part. Is it some text up front to the button?",
-            buttons: [
-              {
-                url: answer_to_question_url(text_component_id: @text_component, index: @text_component.question_answers.index(@next_question_answer)),
-                type: "json_plugin_url",
-                title: @next_question_answer.question
-              }
-          ]
-          },
-          type: "template"
+      messages =  [
+          {
+          attachment: {
+            payload: {
+              template_type: "button",
+              text: "#{@content}",
+              buttons: [
+                {
+                  url: answer_to_question_url(text_component_id: @text_component, index: @text_component.question_answers.index(@next_question_answer) + 1),
+                  type: "json_plugin_url",
+                  title: @next_question_answer.question
+                }
+            ]
+            },
+            type: "template"
+          }
         }
-      }
+      ]
     end
 
     # return this hash

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -70,7 +70,7 @@ class ChatfuelController < ApplicationController
                         "buttons": [
                           {
                             "type": "web_url",
-                            "url": "https://petersapparel.parseapp.com/buy_item?item_id=100",
+                            "url": chatfuel_qa_url(qaId), # generate url for next question
                             "title": "Buy Item"
                           }
                         ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
 
   get 'chatfuel/:topic', to: 'chatfuel#show'
   # route for chatfuel questions and answers
-  get 'chatfuel/:topic/qa/:id', to: 'chatfuel#showQuestionAndAnswer'
+  get 'chatfuel/:topic/qa/:id', to: 'chatfuel#showQuestionAndAnswer', as: 'chatfuel_qa'
 
   resources :reports do
     resources :channels, only: [:edit, :show, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,6 @@ Rails.application.routes.draw do
 
   get 'chatfuel/:topic', to: 'chatfuel#show'
   # route for chatfuel questions and answers
-  get 'chatfuel/:topic/qa/:id', to: 'chatfuel#showQuestionAndAnswer', as: 'chatfuel_qa'
   get 'chatfuel/text_components/:text_component_id/answer_to_question/:index', to: 'chatfuel#answer_to_question', as: 'answer_to_question'
 
   resources :reports do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   get 'reports/preview/:id', to: 'reports#preview', as: 'preview_report'
 
   get 'chatfuel/:topic', to: 'chatfuel#show'
+  # route for chatfuel questions and answers
+  get 'chatfuel/:topic/qa/:id', to: 'chatfuel#showQuestionAndAnswer'
 
   resources :reports do
     resources :channels, only: [:edit, :show, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   get 'chatfuel/:topic', to: 'chatfuel#show'
   # route for chatfuel questions and answers
   get 'chatfuel/:topic/qa/:id', to: 'chatfuel#showQuestionAndAnswer', as: 'chatfuel_qa'
+  get 'chatfuel/text_components/:text_component_id/answer_to_question/:index', to: 'chatfuel#answer_to_question', as: 'answer_to_question'
 
   resources :reports do
     resources :channels, only: [:edit, :show, :update]

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -1,0 +1,76 @@
+@248
+Feature: Read more question
+  As a reader using the Facebook Messenger
+  I want to be asked, if i want to continue reading
+  In order not to be overwhelmed by the amount of text
+  Background:
+    Given a topic "milk_quality"
+    And we have an active text component for that topic with these question/answers:
+      | Question                              | Answer        |
+      | What do you call a sleeping cow?      | A bull-dozer. |
+      | What has one horn and gives milk?     | A milk truck. |
+
+  Scenario: GET request a channel and receive a clickable question
+    When I send a GET request to "/chatfuel/milk_quality"
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "messages": [
+        {
+          "attachment": {
+            "payload": {
+              "template_type": "button",
+              "text": "The main part of the text component will be displayed here.",
+              "buttons": [
+                {
+                  "url": "http://localhost:3000/chatfuel/text_components/1/answer_to_question/1",
+                  "type":"json_plugin_url",
+                  "title":"What do you call a sleeping cow?"
+                }
+              ]
+            },
+            "type": "template"
+          }
+        }
+      ]
+    }
+    """
+
+  Scenario: Click the question and receive the answer along with the next question
+    When I click the question from the first scenario
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "messages": [
+        {
+          "attachment": {
+            "payload":{
+              "template_type": "button",
+              "text": "A bull-dozer.",
+              "buttons": [
+                {
+                  "url": "http://localhost:3000/chatfuel/text_components/1/answer_to_question/2",
+                  "type":"json_plugin_url",
+                  "title": "What has one horn and gives milk?"
+                }
+              ]
+            },
+            "type": "template"
+          }
+        }
+      ]
+    }
+    """
+  Scenario: The last answer in the queue will only send a message
+    When I click the question from the second scenario
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+     "messages": [
+       {"text": "A milk truck."}
+     ]
+    }
+    """

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -5,7 +5,7 @@ Feature: Read more question
   In order not to be overwhelmed by the amount of text
   Background:
     Given a topic "milk_quality"
-    And we have an active text component for that topic with these question/answers:
+    And we have an active text component with the id 1 for that topic with these question/answers:
       | Question                              | Answer        |
       | What do you call a sleeping cow?      | A bull-dozer. |
       | What has one horn and gives milk?     | A milk truck. |
@@ -24,7 +24,7 @@ Feature: Read more question
               "text": "The main part of the text component will be displayed here.",
               "buttons": [
                 {
-                  "url": "http://example.org/chatfuel/text_components/178/answer_to_question/1",
+                  "url": "http://example.org/chatfuel/text_components/1/answer_to_question/1",
                   "type":"json_plugin_url",
                   "title":"What do you call a sleeping cow?"
                 }
@@ -51,7 +51,7 @@ Feature: Read more question
               "text": "A bull-dozer.",
               "buttons": [
                 {
-                  "url": "http://example.org/chatfuel/text_components/179/answer_to_question/2",
+                  "url": "http://example.org/chatfuel/text_components/1/answer_to_question/2",
                   "type":"json_plugin_url",
                   "title": "What has one horn and gives milk?"
                 }

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -24,7 +24,7 @@ Feature: Read more question
               "text": "The main part of the text component will be displayed here.",
               "buttons": [
                 {
-                  "url": "http://localhost:3000/chatfuel/text_components/1/answer_to_question/1",
+                  "url": "http://example.org/chatfuel/text_components/178/answer_to_question/1",
                   "type":"json_plugin_url",
                   "title":"What do you call a sleeping cow?"
                 }
@@ -51,7 +51,7 @@ Feature: Read more question
               "text": "A bull-dozer.",
               "buttons": [
                 {
-                  "url": "http://localhost:3000/chatfuel/text_components/1/answer_to_question/2",
+                  "url": "http://example.org/chatfuel/text_components/179/answer_to_question/2",
                   "type":"json_plugin_url",
                   "title": "What has one horn and gives milk?"
                 }

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -941,9 +941,9 @@ Given(/^we have an active text component for that topic with these question\/ans
 end
 
 When(/^I click the question from the first scenario$/) do
-  request answer_to_question_path(text_component_id: @text_component.id, index: 2)
+  request answer_to_question_path(text_component_id: @text_component.id, index: 1)
 end
 
 When(/^I click the question from the second scenario$/) do
-  request answer_to_question_path(text_component_id: @text_component.id, index: 3)
+  request answer_to_question_path(text_component_id: @text_component.id, index: 2)
 end

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -940,6 +940,20 @@ Given(/^we have an active text component for that topic with these question\/ans
   end
 end
 
+Given(/^we have an active text component with the id (\d+) for that topic with these question\/answers:$/) do |id, table|
+  @text_component = create(:text_component,
+                          channels: [Channel.chatbot],
+                          topic: @topic,
+                          main_part: 'The main part of the text component will be displayed here.',
+                          id: id)
+  table.hashes.each do |row|
+  create(:question_answer,
+         text_component: @text_component,
+         question: row['Question'],
+         answer: row['Answer'])
+  end
+end
+
 When(/^I click the question from the first scenario$/) do
   request answer_to_question_path(text_component_id: @text_component.id, index: 1)
 end

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -927,3 +927,23 @@ Then(/^the text expands like this:$/) do |string|
   check_expanding_report(string)
 end
 
+Given(/^we have an active text component for that topic with these question\/answers:$/) do |table|
+  @text_component = create(:text_component,
+                          channels: [Channel.chatbot],
+                          topic: @topic,
+                          main_part: 'The main part of the text component will be displayed here.')
+  table.hashes.each do |row|
+  create(:question_answer,
+         text_component: @text_component,
+         question: row['Question'],
+         answer: row['Answer'])
+  end
+end
+
+When(/^I click the question from the first scenario$/) do
+  request answer_to_question_path(text_component_id: @text_component.id, index: 2)
+end
+
+When(/^I click the question from the second scenario$/) do
+  request answer_to_question_path(text_component_id: @text_component.id, index: 3)
+end

--- a/spec/controllers/chatfuel_controller_spec.rb
+++ b/spec/controllers/chatfuel_controller_spec.rb
@@ -7,32 +7,43 @@ RSpec.describe ChatfuelController, type: :controller do
   let(:report)            { Report.current }
   let(:topic_name)        { "milk_quality" }
   let(:topic)             { create(:topic, name: topic_name) }
+  let(:params) { { topic: topic_name } }
 
-  context "no text components" do
-    it "returns 404" do
-      get :show, params: {topic: topic_name}, session: valid_session
-      expect(response.code).to eq("404")
-    end
-  end
-
-  context "matching text component" do
-    let(:text_component) do
-      create(
-        :text_component,
-        report: report,
-        topic: topic,
-        channels: [chatbot_channel],
-        main_part: "The main part"
-      )
+  describe 'GET' do
+    subject do
+      get action, params: params, session: valid_session
+      response
     end
 
-    before { text_component }
+    describe 'show' do
+      let(:action) { :show }
 
-    it "returns expected text" do
-      get :show, params: {topic: topic_name}, session: valid_session
-      expect(response.code).to eq("200")
-      json_response = JSON.parse(response.body)
-      expect(json_response["messages"].first["text"]).to eq("The main part")
+      context "no text components" do
+        it "returns 404" do
+          expect(subject.code).to eq("404")
+        end
+      end
+
+      context "matching text component" do
+        let(:text_component) do
+          create(
+            :text_component,
+            report: report,
+            topic: topic,
+            channels: [chatbot_channel],
+            main_part: "The main part"
+          )
+        end
+
+        before { text_component }
+
+        it { is_expected.to have_http_status(:ok) }
+
+        it "returns expected text" do
+          json_response = JSON.parse(subject.body)
+          expect(json_response["messages"].first["text"]).to eq("The main part")
+        end
+      end
     end
   end
 end

--- a/spec/controllers/chatfuel_controller_spec.rb
+++ b/spec/controllers/chatfuel_controller_spec.rb
@@ -16,14 +16,13 @@ RSpec.describe ChatfuelController, type: :controller do
   end
 
   context "matching text component" do
-    let(:main_part) { "Main Part" }
     let(:text_component) do
       create(
         :text_component,
         report: report,
         topic: topic,
         channels: [chatbot_channel],
-        main_part: main_part
+        main_part: "The main part"
       )
     end
 
@@ -32,8 +31,8 @@ RSpec.describe ChatfuelController, type: :controller do
     it "returns expected text" do
       get :show, params: {topic: topic_name}, session: valid_session
       expect(response.code).to eq("200")
-      response = assigns(:response)
-      expect(response[:messages].first[:text]).to eq(main_part)
+      json_response = JSON.parse(response.body)
+      expect(json_response["messages"].first["text"]).to eq("The main part")
     end
   end
 end

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe "Chatfuel", type: :request do
+  describe 'GET' do
+    subject do
+      get url
+      response
+    end
+
+    describe "/chatfuel/text_components/:text_component_id/answer_to_question/:index" do
+      let(:text_component_id) { 1 }
+      let(:index) { 1 }
+      let(:url) { "/chatfuel/text_components/#{text_component_id}/answer_to_question/#{index}" }
+
+      describe 'bogus params' do
+        describe 'bogus index' do
+          before { create(:text_component, id: 1) }
+          let(:index) { 'blah' }
+          it { is_expected.to have_http_status(:not_found) }
+        end
+
+        describe 'no text_component_id' do
+          let(:text_component_id) { 'blah' }
+          it 'raise ActiveRecord::RecordNotFound' do
+            expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+
+      context 'no text component' do
+        it 'raise ActiveRecord::RecordNotFound' do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'text component without question_answer' do
+        before { create(:text_component, id: 1) }
+        it { is_expected.to have_http_status(:not_found) }
+      end
+
+      context 'text component with just one question_answer' do
+        let(:question_answer) { create(:question_answer, question: 'What up?', answer: 'The sun') }
+        before { create(:text_component, id: 1, question_answers: [question_answer]) }
+
+        it { is_expected.to have_http_status(:ok) }
+
+        it 'reveals the answer to the question' do
+          json_response = JSON.parse(subject.body)
+          expect(json_response['messages'][0]['text']).to eq 'The sun'
+        end
+      end
+
+      context 'text component with two question_answers' do
+        let(:question_answers) { create_list(:question_answer, 2, question: 'What up?', answer: 'The sun') }
+        before { create(:text_component, id: 1, question_answers: question_answers) }
+
+        it 'reveals the answer to the question' do
+          json_response = JSON.parse(subject.body)
+          expect(json_response['messages'][0]['attachment']['payload']['text']).to eq 'The sun'
+        end
+
+        it 'shows a button attachment' do
+          json_response = JSON.parse(subject.body)
+          expect(json_response['messages'][0]['attachment']['payload']['template_type']).to eq 'button'
+        end
+
+        describe 'index == 2' do
+          let(:index) { 2 }
+
+          it 'reveals last answer as a single message' do
+            json_response = JSON.parse(subject.body)
+            expect(json_response['messages'][0]['text']).to eq 'The sun'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the pull request for issue #248.

If a text component contains question and answers, send button with question to chatfuel. As long as there are more questions, keep sending the answer of the last question and a button for the new question.

The formatting is not always right in this commit (indentation with 4 chars vs. 2 chars), this needs to be addressed later.

---

close #248