### PR TITLE
Added ingredients menu for sensors and events

### DIFF
--- a/app/assets/javascripts/text_components.coffee
+++ b/app/assets/javascripts/text_components.coffee
@@ -1,6 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://coffeescript.org/
-
-
-

--- a/app/assets/javascripts/text_components.js
+++ b/app/assets/javascripts/text_components.js
@@ -1,0 +1,146 @@
+/*
+ * Place all the behaviors and hooks related to the matching controller here.
+ * All this logic will automatically be available in application.js.
+ */
+
+var Editor = (function($) {
+
+    /*
+     * Creates an instance of the Editor class
+     * 
+     * @constructor
+     * @param {jQuery} $editor The wrapping text editor element
+     */
+    function Editor($editor) {
+        this.$editor  = $editor;
+        this.$toolbar = $editor.find('.text-editor__toolbar:first');
+        this.$fields  = $editor.find('.text-editor__field');
+
+        this.init();
+
+        var self = this;
+
+        /*
+         * By adding or removing elements to the commands property,
+         * you can add custom commands, e. g. to insert the markup
+         * for an image or a link.
+         *
+         * @type {function[]}
+         */
+        this.commands = {
+            'text': function($context) {
+                return $context.data().editorMarkupText;
+            },
+        };
+    };
+
+    /*
+     * Sets event listeners on the editor and its child elements
+     * 
+     * @returns {Editor}
+     */
+    Editor.prototype.init = function() {
+        var self = this;
+
+        // Prevent loosing focus when clicking toolbar buttons
+        self.$toolbar.on('mousedown', function(e) {
+            e.preventDefault();
+        });
+
+        self.$toolbar.find('[data-editor-markup-command]').on('click', function(e) {
+            e.preventDefault();
+
+            var command = self.commands[$(this).data().editorMarkupCommand];
+
+            if(typeof command !== 'function') throw new Error('Command not defined: ' + $(this).data().editorMarkupCommand);
+            
+            self.insertText(command($(this)));
+        });
+
+        return this;
+    };
+
+    /*
+     * Inserts a string at the current cursor position in the
+     * currently active field
+     * 
+     * @param {string} string The text to be inserted
+     * @returns {Editor}
+     */
+    Editor.prototype.insertText = function(string) {
+        var $activeField = $(':input:focus:first', this.$editor);
+
+        if($activeField.length > 0) {
+            var field = new Field($activeField);
+            field.insertText(string);
+        }
+
+        return this;
+    };
+
+    /*
+     * Creates an instance of the Field class
+     *
+     * @constructor
+     * @param {jQuery} $field The field element
+     * @param {Editor} editor The editor the field belongs to
+     */
+    function Field($field, editor) {
+        this.$field = $field;
+
+        this.editor = editor;
+    };
+
+    /*
+     * Gets the start and end position of the selection in the
+     * field. If no text is selected, returns the position of the
+     * character after the cursor. If the field is not active,
+     * returns the position after the last character.
+     *
+     * @returns {Object} Object with 'start' and 'end' properties
+     * representing the start end end of the selection
+     */
+    Field.prototype.getSelection = function() {
+        var start  = this.$field.get(0).selectionStart,
+            end    = this.$field.get(0).selectionEnd,
+            length = this.$field.val().length;
+
+        return {
+            start: start !== undefined ? start : length,
+            end:   end !== undefined ? end : length,
+        };
+    };
+
+    /*
+     * Inserts text at the current cursor position. If text is
+     * selected, the current selection will be replaced.
+     * 
+     * @param {string} string The text to be inserted
+     * @returns {Field}
+     */
+    Field.prototype.insertText = function(string) {
+        var value     = this.$field.val(),
+            selection = this.getSelection();
+
+        this.$field.val(value.substring(0, selection.start) + string + value.substring(selection.end, value.length));
+
+        return this;
+    };
+
+    return Editor;
+
+})(jQuery);
+
+(function($, Editor) {
+
+    $.fn.editor = function() {
+        this.each(function() {
+            var editor = new Editor($(this));
+        });
+    };
+
+    $(function() {
+        $('.modal .text-editor').editor();
+    });
+
+})(jQuery, Editor);

--- a/app/assets/stylesheets/text_components.scss
+++ b/app/assets/stylesheets/text_components.scss
@@ -263,7 +263,6 @@ to order!
 
 .seamless-textarea {
   //background: #ddd;
-  padding: 20px 0;
 }
 .seamless-textarea textarea {
   //font-family: Georgia, serif;
@@ -360,4 +359,49 @@ RADIO BOXES
   .introduction {
     font-style: italic;
   }
+}
+
+
+/*
+ * TEXT-EDITOR
+ */
+
+/* quick fix solving issues with sticky elements inside modals */
+.modal.in .modal-dialog {
+  transform: none;
+}
+
+.text-editor {
+
+}
+
+.text-editor__toolbar {
+  position: sticky;
+  top: 0;
+
+  /* magic numbers, should be replaced by bootstrap’s coresponsing variables */
+  margin: 0 -15px 15px;
+  padding: 0 15px;
+
+  background-color: #efefef;
+}
+
+.text-editor__toolbar__item {
+  display: inline-block;
+  cursor: pointer;
+
+  /* magic numbers, see above */
+  padding: 15px 5px;
+
+  &:hover {
+    color: darken(#428bca, 10);
+  }
+}
+
+.text-editor__toolbar__item .glyphicon {
+  font-size: 1.25em;
+  /* resetting the icon position */
+  line-height: .8; /* 1/1.25 */
+  top: .125em; /* (1.25-1)/2 */
+
 }

--- a/app/controllers/text_components_controller.rb
+++ b/app/controllers/text_components_controller.rb
@@ -5,6 +5,7 @@ class TextComponentsController < ApplicationController
   # GET /text_components.json
   def index
     set_triggers_and_text_components
+    set_sensors_and_events
     @text_component = @new_text_component
   end
 
@@ -79,6 +80,11 @@ class TextComponentsController < ApplicationController
       @triggers = Trigger.includes(text_components: [:question_answers, :channels])
       @remaining_text_components = TextComponent.left_joins(:triggers).includes(:triggers).distinct
       @remaining_text_components = @remaining_text_components.select{|t| t.triggers.empty?}
+    end
+
+    def set_sensors_and_events
+      @sensors = Sensor.all
+      @events = Event.all
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/text_components_controller.rb
+++ b/app/controllers/text_components_controller.rb
@@ -33,6 +33,7 @@ class TextComponentsController < ApplicationController
       else
         format.html do
           set_triggers_and_text_components
+          set_sensors_and_events
           render :index
         end
         format.json { render json: @text_component.errors, status: :unprocessable_entity }
@@ -50,6 +51,7 @@ class TextComponentsController < ApplicationController
       else
         format.html do
           set_triggers_and_text_components
+          set_sensors_and_events
           render :index
         end
         format.json { render json: @text_component.errors, status: :unprocessable_entity }

--- a/app/controllers/text_components_controller.rb
+++ b/app/controllers/text_components_controller.rb
@@ -4,8 +4,7 @@ class TextComponentsController < ApplicationController
   # GET /text_components
   # GET /text_components.json
   def index
-    set_triggers_and_text_components
-    set_sensors_and_events
+    set_instance_variables
     @text_component = @new_text_component
   end
 
@@ -32,8 +31,7 @@ class TextComponentsController < ApplicationController
         format.json { render :show, status: :created, location: @text_component }
       else
         format.html do
-          set_triggers_and_text_components
-          set_sensors_and_events
+          set_instance_variables
           render :index
         end
         format.json { render json: @text_component.errors, status: :unprocessable_entity }
@@ -50,8 +48,7 @@ class TextComponentsController < ApplicationController
         format.json { render :show, status: :ok, location: @text_component }
       else
         format.html do
-          set_triggers_and_text_components
-          set_sensors_and_events
+          set_instance_variables
           render :index
         end
         format.json { render json: @text_component.errors, status: :unprocessable_entity }
@@ -75,16 +72,13 @@ class TextComponentsController < ApplicationController
       @text_component = TextComponent.find(params[:id])
     end
 
-    def set_triggers_and_text_components
+    def set_instance_variables
       @new_text_component = TextComponent.new
       @new_text_component.triggers.build
       @new_text_component.report = Report.current
       @triggers = Trigger.includes(text_components: [:question_answers, :channels])
       @remaining_text_components = TextComponent.left_joins(:triggers).includes(:triggers).distinct
       @remaining_text_components = @remaining_text_components.select{|t| t.triggers.empty?}
-    end
-
-    def set_sensors_and_events
       @sensors = Sensor.all
       @events = Event.all
     end

--- a/app/views/question_answers/_fields.html.haml
+++ b/app/views/question_answers/_fields.html.haml
@@ -1,10 +1,10 @@
 .nested-fields
   .row
     .col
-      = f.input :question, input_html: { class: 'question-input' }
+      = f.input :question, input_html: { class: ['question-input', 'text-editor__field'] }
   .row
     .col
-      = f.input :answer, input_html: { class: 'answer-input' }
+      = f.input :answer, input_html: { class: ['answer-input', 'text-editor__field'] }
   .row
     .col
       = link_to_remove_association button_tag("Remove question/answer", type: 'button', class: 'btn btn-danger'), f

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -28,18 +28,6 @@
     .text-editor
       .text-editor__toolbar
         %ul.list-inline
-          %li
-            .text-editor__toolbar__item
-              %span.glyphicon.glyphicon-picture{"aria-label" => "Picture"}
-          %li
-            .text-editor__toolbar__item
-              %span.glyphicon.glyphicon-facetime-video{"aria-label" => "Video"}
-          %li
-            .text-editor__toolbar__item
-              %span.glyphicon.glyphicon-play{"aria-label" => "Audio"}
-          %li
-            .text-editor__toolbar__item
-              %span.glyphicon.glyphicon-link{"aria-label" => "Link"}
           %li.dropdown
             .text-editor__toolbar__item.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
               Sensors

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -26,35 +26,34 @@
     %h2 Text
     %p.help Please write the text here. To add dynamic fields, like temperature values via toolbar.
     .text-editor
-      %ul.text-editor__toolbar
-        %li.text-editor__toolbar__item
-          %a.btn.btn-primary{:href => "#"}
-            %span.glyphicon.glyphicon-picture{"aria-label" => "Picture"}
-        %li.text-editor__toolbar__item
-          %a.btn.btn-primary{:href => "#"}
-            %span.glyphicon.glyphicon-facetime-video{"aria-label" => "Video"}
-        %li.text-editor__toolbar__item
-          %a.btn.btn-primary{:href => "#"}
-            %span.glyphicon.glyphicon-play{"aria-label" => "Audio"}
-        %li.text-editor__toolbar__item
-          %a.btn.btn-primary{:href => "#"}
-            %span.glyphicon.glyphicon-link{"aria-label" => "Link"}
-        %li.text-editor__toolbar__item
-          .dropdown
-            %a.btn.btn-primary.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
-              %span.glyphicon.glyphicon-plus{"aria-hidden" => "true"}
+      .text-editor__toolbar
+        %ul.list-inline
+          %li
+            .text-editor__toolbar__item
+              %span.glyphicon.glyphicon-picture{"aria-label" => "Picture"}
+          %li
+            .text-editor__toolbar__item
+              %span.glyphicon.glyphicon-facetime-video{"aria-label" => "Video"}
+          %li
+            .text-editor__toolbar__item
+              %span.glyphicon.glyphicon-play{"aria-label" => "Audio"}
+          %li
+            .text-editor__toolbar__item
+              %span.glyphicon.glyphicon-link{"aria-label" => "Link"}
+          %li.dropdown
+            .text-editor__toolbar__item.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
               Sensors
+              %span.caret{"aria-hidden" => "true"}
             %ul.dropdown-menu
               - @sensors.each do |sensor|
                 %li
                   %a{:href => "#", :data => {"editor" => {"markup-command" => "text", "markup-text" => "{value(#{sensor.id})}"}}}
                     = sensor.name
-        %li.text-editor__toolbar__item
-          .dropdown
-            %a.btn.btn-primary.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
-              %span.glyphicon.glyphicon-plus{"aria-hidden" => "true"}
+          %li.dropdown
+            .text-editor__toolbar__item.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
               Events
-            %ul.dropdown-menu
+              %span.caret{"aria-hidden" => "true"}
+            %ul.dropdown-menu.text-editor__toolbar__dropdown__menu
               - @events.each do |event|
                 %li
                   %a{:href => "#", :data => {"editor" => {"markup-command" => "text", "markup-text" => "{date(#{event.id})}"}}}

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -23,63 +23,54 @@
       .col-sm-6
         = f.input :to_day
 
-    .row
-      .col-sm-12
-        %h2 Text
-        %div.help Please write the text here. To add dynamic fields, like temperature values via toolbar.
-      .col-sm-12
-        / Split button
-        .btn-group.pull-right
-          %button.btn.btn-primary{:type => "button"}
-            %span.glyphicon.glyphicon-plus{"aria-hidden" => "true"}
-            Ingredients
-          %button.btn.btn-primary.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
-            %span.caret
-            %span.sr-only
-          %ul.dropdown-menu
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-picture{"aria-hidden" => "true"}
-                Picture
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-facetime-video{"aria-hidden" => "true"}
-                Video
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-play{"aria-hidden" => "true"}
-                Audio
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-link{"aria-hidden" => "true"}
-                Link
-            %li.divider{:role => "separator"}
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-tag{"aria-hidden" => "true"}
-                Markup 1
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-tag{"aria-hidden" => "true"}
-                Markup 2
-            %li
-              %a{:href => "#"}
-                %span.glyphicon.glyphicon-tag{"aria-hidden" => "true"}
-                Markup 3
-    %div.seamless-textarea.text-component-input-fields
-      = f.input :heading, as: :text, placeholder: 'Title', label: false
-      = f.input :introduction, as: :text, placeholder: 'Introduction', label: false, input_html: { class: 'introduction' }
-      = f.input :main_part, as: :text, placeholder: 'Main part', label: false, input_html: { rows: 10 }
-      = f.input :closing, as: :text, placeholder: 'Closing', label: false
-    .row
-      .col-sm-12
-        %h2 Questions/Answers for Chatfuel
-        .container-fluid
-          = f.simple_fields_for :question_answers do |question_answer|
-            = render 'question_answers/fields', f: question_answer
-          .links
-            .row
-              = link_to_add_association button_tag("Add a question and an answer", type: 'button', class: 'btn btn-primary'), f, :question_answers, partial: 'question_answers/fields.html.haml'
+    %h2 Text
+    %p.help Please write the text here. To add dynamic fields, like temperature values via toolbar.
+    .text-editor
+      %ul.text-editor__toolbar
+        %li.text-editor__toolbar__item
+          %a.btn.btn-primary{:href => "#"}
+            %span.glyphicon.glyphicon-picture{"aria-label" => "Picture"}
+        %li.text-editor__toolbar__item
+          %a.btn.btn-primary{:href => "#"}
+            %span.glyphicon.glyphicon-facetime-video{"aria-label" => "Video"}
+        %li.text-editor__toolbar__item
+          %a.btn.btn-primary{:href => "#"}
+            %span.glyphicon.glyphicon-play{"aria-label" => "Audio"}
+        %li.text-editor__toolbar__item
+          %a.btn.btn-primary{:href => "#"}
+            %span.glyphicon.glyphicon-link{"aria-label" => "Link"}
+        %li.text-editor__toolbar__item
+          .dropdown
+            %a.btn.btn-primary.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
+              %span.glyphicon.glyphicon-plus{"aria-hidden" => "true"}
+              Sensors
+            %ul.dropdown-menu
+              - @sensors.each do |sensor|
+                %li
+                  %a{:href => "#", :data => {"editor" => {"markup-command" => "text", "markup-text" => "{value(#{sensor.id})}"}}}
+                    = sensor.name
+        %li.text-editor__toolbar__item
+          .dropdown
+            %a.btn.btn-primary.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :type => "button"}
+              %span.glyphicon.glyphicon-plus{"aria-hidden" => "true"}
+              Events
+            %ul.dropdown-menu
+              - @events.each do |event|
+                %li
+                  %a{:href => "#", :data => {"editor" => {"markup-command" => "text", "markup-text" => "{date(#{event.id})}"}}}
+                    = event.name
+      .seamless-textarea.text-component-input-fields
+        = f.input :heading, as: :text, :placeholder => 'Title', :label => false, :input_html => { :class => 'text-editor__field'}
+        = f.input :introduction, as: :text, :placeholder => 'Introduction', :label => false, :input_html => { :class => ['text-editor__field', 'introduction'] }
+        = f.input :main_part, as: :text, :placeholder => 'Main part', :label => false, :input_html => { :rows => 10, :class => 'text-editor__field' }
+        = f.input :closing, as: :text, :placeholder => 'Closing', :label => false, :input_html => { :class => 'text-editor__field'}
+      %h2 Questions/Answers for Chatfuel
+      .container-fluid
+        = f.simple_fields_for :question_answers do |question_answer|
+          = render 'question_answers/fields', f: question_answer
+        .links
+          .row
+            = link_to_add_association button_tag("Add a question and an answer", type: 'button', class: 'btn btn-primary'), f, :question_answers, partial: 'question_answers/fields.html.haml'
     .row
       .col-sm-12
         %h2 Output

--- a/spec/views/text_components/index.html.haml_spec.rb
+++ b/spec/views/text_components/index.html.haml_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "text_components/index", type: :view do
     expect(rendered).to include('Events')
   end
 
-  it "contains dropdown menus for sensors and events to insert markup into textareas"
+  it "contains dropdown menus for sensors and events to insert markup into textareas" do
     render
     parsed = Capybara.string(rendered)
     parsed.all('form').each do |form|

--- a/spec/views/text_components/index.html.haml_spec.rb
+++ b/spec/views/text_components/index.html.haml_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe "text_components/index", type: :view do
     new_text_component.triggers.build
     assign(:new_text_component, new_text_component)
     assign(:triggers, [])
+    assign(:sensors, [
+      create(
+        :sensor,
+        :name => "Sensor Name",
+      )
+    ])
+    assign(:events, [
+      create(
+        :event,
+        :name => "Event Name",
+      )
+    ])
     assign(:remaining_text_components, [
       create(
         :text_component,
@@ -36,6 +48,14 @@ RSpec.describe "text_components/index", type: :view do
   it "shows trigger fields, e.g. the events menu" do
     render
     expect(rendered).to include('Events')
+  end
+
+  it "contains dropdown menus for sensors and events to insert markup into textareas"
+    render
+    parsed = Capybara.string(rendered)
+    parsed.all('form').each do |form|
+      expect(form).to have_selector('.text-editor__toolbar__item.dropdown-toggle', :count => 2)
+    end
   end
 
   it 'will never show two seperate report input fields in one form' do


### PR DESCRIPTION
I added dropdowns for events and sensors to add the corresponsing markup to the text fields in the edit modal and slightly changed the appearance of the toolbar improving the ux especially with long forms.

--

#207,  #325