### PR TITLE
Button with link to block after last question and answer

### DIFF
--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -53,6 +53,26 @@ class ChatfuelController < ApplicationController
           }
         }
       ]
+    elsif @question_answer && !@next_question_answer
+      topic = @text_component.topic
+      messages =  [
+          {
+          attachment: {
+            payload: {
+              template_type: "button",
+              text: "#{content}",
+              buttons: [
+                {
+                  type: "show_block",
+                  block_name: "cont_" + topic.name,
+                  title: "Zurück",
+                }
+            ]
+            },
+            type: "template"
+          }
+        }
+      ]
     else
       messages =  [
         { text: content.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -14,9 +14,10 @@ class ChatfuelController < ApplicationController
 
   def answer_to_question
     @text_component = TextComponent.includes(:question_answers).find(params[:text_component_id])
+    @topic = @text_component.topic
     index = params[:index].to_i - 1
     @question_answer = @text_component.question_answers[index]
-    if @question_answer
+    if @question_answer && @topic
       @next_question_answer = @text_component.question_answers[index + 1]
       render json: json_response
     else
@@ -54,7 +55,6 @@ class ChatfuelController < ApplicationController
         }
       ]
     elsif @question_answer && !@next_question_answer
-      topic = @text_component.topic
       messages =  [
           {
           attachment: {
@@ -64,7 +64,7 @@ class ChatfuelController < ApplicationController
               buttons: [
                 {
                   type: "show_block",
-                  block_name: "cont_" + topic.name,
+                  block_name: "cont_" + @topic.name,
                   title: "Zurück",
                 }
             ]

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -63,14 +63,29 @@ Feature: Read more question
       ]
     }
     """
-  Scenario: The last answer in the queue will only send a message
+  Scenario: The last answer in the queue will send an answer and a button linking to a block, dependant on the topic (block name: cont_[topic])
     When I click the question from the second scenario
     Then the response status should be "200"
     And the JSON response should be:
     """
     {
-     "messages": [
-       {"text": "A milk truck."}
-     ]
+      "messages": [
+        {
+          "attachment": {
+            "payload":{
+              "template_type": "button",
+              "text": "A milk truck.",
+              "buttons": [
+                {
+                  "type": "show_block",
+                  "block_name":"cont_milk_quality",
+                  "title": "Zurück"
+                }
+              ]
+            },
+            "type": "template"
+          }
+        }
+      ]
     }
     """

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -40,20 +40,22 @@ RSpec.describe "Chatfuel", type: :request do
       end
 
       context 'text component with just one question_answer' do
+        let(:topic) { create(:topic, id: 1, name: "milk_quality") }
         let(:question_answer) { create(:question_answer, question: 'What up?', answer: 'The sun') }
-        before { create(:text_component, id: 1, question_answers: [question_answer]) }
+        before { create(:text_component, id: 1, question_answers: [question_answer], topic: topic) }
 
         it { is_expected.to have_http_status(:ok) }
 
         it 'reveals the answer to the question' do
           json_response = JSON.parse(subject.body)
-          expect(json_response['messages'][0]['text']).to eq 'The sun'
+          expect(json_response['messages'][0]['attachment']['payload']['text']).to eq 'The sun'
         end
       end
 
       context 'text component with two question_answers' do
+        let(:topic) { create(:topic, id: 1, name: "milk_quality") }
         let(:question_answers) { create_list(:question_answer, 2, question: 'What up?', answer: 'The sun') }
-        before { create(:text_component, id: 1, question_answers: question_answers) }
+        before { create(:text_component, id: 1, question_answers: question_answers, topic: topic) }
 
         it 'reveals the answer to the question' do
           json_response = JSON.parse(subject.body)
@@ -68,9 +70,9 @@ RSpec.describe "Chatfuel", type: :request do
         describe 'index == 2' do
           let(:index) { 2 }
 
-          it 'reveals last answer as a single message' do
+          it 'reveals last answer to the question' do
             json_response = JSON.parse(subject.body)
-            expect(json_response['messages'][0]['text']).to eq 'The sun'
+            expect(json_response['messages'][0]['attachment']['payload']['text']).to eq 'The sun'
           end
         end
       end

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe "Chatfuel", type: :request do
         it { is_expected.to have_http_status(:not_found) }
       end
 
+      context 'text component with one question_answer and without topic' do
+        let(:question_answer) { create(:question_answer, question: 'What up?', answer: 'The sun') }
+        before { create(:text_component, id: 1, question_answers: [question_answer], topic: nil) }
+        it { is_expected.to have_http_status(404) }
+      end
+
       context 'text component with just one question_answer' do
         let(:topic) { create(:topic, id: 1, name: "milk_quality") }
         let(:question_answer) { create(:question_answer, question: 'What up?', answer: 'The sun') }

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -13,15 +13,6 @@ RSpec.describe "Chatfuel", type: :request do
       let(:chatbot_channel)   { Channel.chatbot }
       let(:report)            { Report.current }
 
-      describe 'bogus topic' do
-        let(:topic_id) { 'blah' }
-        it { is_expected.to have_http_status(:not_found) }
-      end
-
-      describe 'topic doesn\'t exist' do
-        it { is_expected.to have_http_status(404) }
-      end
-
       describe 'text component doesn\'t exist' do
         before { create(:topic, id: 1, name: "milk_quality") }
         it { is_expected.to have_http_status(404) }
@@ -36,7 +27,8 @@ RSpec.describe "Chatfuel", type: :request do
             report: report,
             topic: topic,
             channels: [chatbot_channel],
-            main_part: "The main part"
+            main_part: "The main part",
+            id: 1
           )
         end
 


### PR DESCRIPTION
With the last answer of a question & answer list a button is sent linking to a block (name pattern for the block is cont_+[topic]) in order to continue with the conversation.

---
Close #340