### PR TITLE
Changed block name to continue_topic.id

### DIFF
--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -64,7 +64,7 @@ class ChatfuelController < ApplicationController
               buttons: [
                 {
                   type: "show_block",
-                  block_name: "cont_" + @topic.name,
+                  block_name: "continue_" + @topic.name,
                   title: "Zurück",
                 }
             ]

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -65,7 +65,7 @@ class ChatfuelController < ApplicationController
                 {
                   type: "show_block",
                   block_name: "continue_" + @topic.name,
-                  title: "Zurück",
+                  title: "Danke",
                 }
             ]
             },

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -78,7 +78,7 @@ Feature: Read more question
               "buttons": [
                 {
                   "type": "show_block",
-                  "block_name":"cont_milk_quality",
+                  "block_name":"continue_milk_quality",
                   "title": "Zurück"
                 }
               ]

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -79,7 +79,7 @@ Feature: Read more question
                 {
                   "type": "show_block",
                   "block_name":"continue_milk_quality",
-                  "title": "Zurück"
+                  "title": "Danke"
                 }
               ]
             },


### PR DESCRIPTION
I changed the pattern of the continue block from cont_topic.id to continue_topic.id

I didn't see that the other branch was already merged, please delete this pull request if the merged branch is suficcient.

Referencing #340