### PR TITLE
Show last answer & redirect if question answers are empty

### DIFF
--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -36,53 +36,39 @@ class ChatfuelController < ApplicationController
     end
 
     if @next_question_answer
-      messages =  [
-          {
-          attachment: {
-            payload: {
-              template_type: "button",
-              text: "#{content}",
-              buttons: [
-                {
-                  url: answer_to_question_url(text_component_id: @text_component, index: @text_component.question_answers.index(@next_question_answer) + 1),
-                  type: "json_plugin_url",
-                  title: @next_question_answer.question
-                }
-            ]
-            },
-            type: "template"
+      {
+        messages: [
+            {
+            attachment: {
+              payload: {
+                template_type: "button",
+                text: "#{content}",
+                buttons: [
+                  {
+                    url: answer_to_question_url(text_component_id: @text_component, index: @text_component.question_answers.index(@next_question_answer) + 1),
+                    type: "json_plugin_url",
+                    title: @next_question_answer.question
+                  }
+              ]
+              },
+              type: "template"
+            }
           }
-        }
-      ]
+        ]
+      }
     elsif @question_answer && !@next_question_answer
-      messages =  [
-          {
-          attachment: {
-            payload: {
-              template_type: "button",
-              text: "#{content}",
-              buttons: [
-                {
-                  type: "show_block",
-                  block_name: "continue_" + @topic.name,
-                  title: "Danke",
-                }
-            ]
-            },
-            type: "template"
-          }
-        }
-      ]
+      {
+        messages: [
+            { text: content.first(640) }
+        ],
+        redirect_to_blocks: ["continue_" + @topic.name]
+      }
     else
-      messages =  [
-        { text: content.first(640)} # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
-      ]
+      {
+        messages: [
+          { text: content.first(640) } # Messages for Facebook Messenger can only be 640 characters long. Source: https://developers.facebook.com/docs/messenger-platform/send-api-reference#request
+        ]
+      }
     end
-
-    # return this hash
-    {
-      messages: messages
-    }
-
   end
 end

--- a/features/channels/question_answer.feature
+++ b/features/channels/question_answer.feature
@@ -63,7 +63,7 @@ Feature: Read more question
       ]
     }
     """
-  Scenario: The last answer in the queue will send an answer and a button linking to a block, dependant on the topic (block name: cont_[topic])
+  Scenario: The last answer in the queue will send an answer and redirect to a block, dependant on the topic (block name: continue_[topic.name])
     When I click the question from the second scenario
     Then the response status should be "200"
     And the JSON response should be:
@@ -71,21 +71,9 @@ Feature: Read more question
     {
       "messages": [
         {
-          "attachment": {
-            "payload":{
-              "template_type": "button",
-              "text": "A milk truck.",
-              "buttons": [
-                {
-                  "type": "show_block",
-                  "block_name":"continue_milk_quality",
-                  "title": "Danke"
-                }
-              ]
-            },
-            "type": "template"
-          }
+          "text": "A milk truck."
         }
-      ]
+      ],
+      "redirect_to_blocks": ["continue_milk_quality"]
     }
     """

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Chatfuel", type: :request do
 
         it 'reveals the answer to the question' do
           json_response = JSON.parse(subject.body)
-          expect(json_response['messages'][0]['attachment']['payload']['text']).to eq 'The sun'
+          expect(json_response['messages'][0]['text']).to eq 'The sun'
         end
       end
 
@@ -112,7 +112,7 @@ RSpec.describe "Chatfuel", type: :request do
 
           it 'reveals last answer to the question' do
             json_response = JSON.parse(subject.body)
-            expect(json_response['messages'][0]['attachment']['payload']['text']).to eq 'The sun'
+            expect(json_response['messages'][0]['text']).to eq 'The sun'
           end
         end
       end


### PR DESCRIPTION
Instead of linking to a continue block, the user now gets redirected when questions and answers are empty.

Referencing #340 