### PR TITLE
355 sort dropdowns

### DIFF
--- a/app/controllers/text_components_controller.rb
+++ b/app/controllers/text_components_controller.rb
@@ -75,8 +75,8 @@ class TextComponentsController < ApplicationController
     end
 
     def set_form_data
-      @sensors = Sensor.all
-      @events = Event.all
+      @sensors = Sensor.order('name')
+      @events = Event.order('name')
     end
 
     def set_index_data

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -2,7 +2,7 @@
   = f.error_notification
 
   .form-inputs
-    = f.association :report, selected: @report.id
+    = f.association :report, collection: Report.order('name'), selected: @report.id
     .row
       .col-sm-12
         #triggers
@@ -10,15 +10,15 @@
             = f.simple_fields_for :triggers do |trigger|
               = render 'triggers/trigger_fields', f: trigger, is_sub_form: true
           - else
-            = f.association :triggers, label_method: :name, input_html: {'class' => 'selectpicker', 'data-live-search' => "true", 'title' => '...choose a trigger'}
+            = f.association :triggers, collection: Trigger.order('name'), label_method: :name, input_html: {'class' => 'selectpicker', 'data-live-search' => "true", 'title' => '...choose a trigger'}
 
     .row
       .col-sm-12
-        = f.association :assignee, label_method: :name, input_html: {'title' => '...choose an assignee'}
+        = f.association :assignee, collection: User.order('LOWER(name)'), label_method: :name, input_html: {'title' => '...choose an assignee'}
     .row
       .col-sm-12
         #topic
-          = f.association :topic, label_method: :name, input_html: {'class' => 'selectpicker', 'data-live-search' => "true", 'title' => '...choose a topic'}
+          = f.association :topic, collection: Topic.order('name'), label_method: :name, input_html: {'class' => 'selectpicker', 'data-live-search' => "true", 'title' => '...choose a topic'}
 
     .row
       .col-sm-6
@@ -65,6 +65,6 @@
       .col-sm-12
         %h2 Output
         #channels
-          = f.association :channels
+          = f.association :channels, collection: Channel.order('name')
   .form-actions
     = f.button :submit

--- a/app/views/text_components/index.html.haml
+++ b/app/views/text_components/index.html.haml
@@ -52,7 +52,7 @@
     = form_tag(report_text_components_path(@report), {method: :get}) do
       .form-group
         = label :filter, :assignee_id, 'By assignee', class: 'col-2 col-form-label'
-        = collection_select(:filter, :assignee_id, User.all, :id, :name, {include_blank: true, selected: @filter[:assignee_id]}, {'class' => 'selectpicker', 'title' => '...choose a user'})
+        = collection_select(:filter, :assignee_id, User.order('LOWER(name)'), :id, :name, {include_blank: true, selected: @filter[:assignee_id]}, {'class' => 'selectpicker', 'title' => '...choose a user'})
       = submit_tag 'Filter', class: 'col-2 btn btn-primary btn-lg pull-right'
 .row
   .col-sm-12

--- a/app/views/triggers/_condition_fields.html.haml
+++ b/app/views/triggers/_condition_fields.html.haml
@@ -7,7 +7,7 @@
         - else
           = f.index + 1
     .col-sm-3
-      = f.association :sensor, label_method: :name_and_id, value_method: :id, label: false, prompt: '...add Sensor', input_html: {class: 'choose_sensor'}
+      = f.association :sensor, collection: Sensor.order('name'), label_method: :name_and_id, value_method: :id, label: false, prompt: '...add Sensor', input_html: {class: 'choose_sensor'}
     .col-sm-6
       .range-group
         = f.input :from, as: :hidden, input_html: { class: 'range-slider-min-value' }

--- a/app/views/triggers/_trigger_fields.html.haml
+++ b/app/views/triggers/_trigger_fields.html.haml
@@ -3,7 +3,7 @@
     .col-sm-12
       %h2 Trigger
       %div.help Define a new Trigger first.
-      = f.association :report, selected: @report.id unless local_assigns[:is_sub_form]
+      = f.association :report, collection: Report.order('name'), selected: @report.id unless local_assigns[:is_sub_form]
     .col-sm-6
       = f.input :name
     .col-sm-6


### PR DESCRIPTION
Select options in forms related to text components or triggers will now be sorted alphabetically.

Sorting for users selects is case-insensitive. Options for all other selects are displayed in default alphabetic order to avoid affecting query performance.

close #355 