### PR TITLE
385 Chatfuel api request return text_component based on topic.name

### DIFF
--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -3,7 +3,8 @@ class ChatfuelController < ApplicationController
     @topic = Topic.find_by(name: params[:topic])
 
     if @topic
-      @text_component = Text::Sorter.sort(@topic.text_components, {}).first
+      text_components = Channel.chatbot.text_components.where(:topic => @topic)
+      @text_component = Text::Sorter.sort(text_components, {}).first
 
       if @text_component
         @next_question_answer = @text_component.question_answers.first

--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -1,12 +1,16 @@
 class ChatfuelController < ApplicationController
   def show
-    chatbot_channel = Channel.chatbot
+    @topic = Topic.find_by(name: params[:topic])
 
-    @text_component = Text::Sorter.sort(chatbot_channel.text_components, {}).first
+    if @topic
+      @text_component = Text::Sorter.sort(@topic.text_components, {}).first
 
-    if @text_component
-      @next_question_answer = @text_component.question_answers.first
-      render json: json_response
+      if @text_component
+        @next_question_answer = @text_component.question_answers.first
+        render json: json_response
+      else
+        render json: {}, status: 404
+      end
     else
       render json: {}, status: 404
     end

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Chatfuel", type: :request do
         it { is_expected.to have_http_status(404) }
       end
 
-      describe 'text compoent with wrong topic' do
+      describe 'text component with wrong topic' do
         let(:topic) { create(:topic, id: 2, name: "milk_quantity") }
 
         before do
@@ -39,7 +39,7 @@ RSpec.describe "Chatfuel", type: :request do
         it { is_expected.to have_http_status(404) }
       end
 
-      describe 'text compoent with wrong channel' do
+      describe 'text component with wrong channel' do
         let(:topic) { create(:topic, id: 1, name: "milk_quality") }
 
         before do
@@ -75,6 +75,29 @@ RSpec.describe "Chatfuel", type: :request do
         it 'should show text component text' do
           json_response = JSON.parse(subject.body)
           expect(json_response['messages'][0]['text']).to eq 'The main part'
+        end
+      end
+
+      describe 'existing topic adorable kitten' do
+        let(:topic) { create(:topic, id: 1, name: "adorable_kitten") }
+        let(:topic_name) { "adorable_kitten" }
+
+        before do
+          create(
+            :text_component,
+            report: report,
+            topic: topic,
+            channels: [chatbot_channel],
+            main_part: "Purr Purr",
+            id: 1
+          )
+        end
+
+        it { is_expected.to have_http_status(:ok) }
+
+        it 'should show text component text' do
+          json_response = JSON.parse(subject.body)
+          expect(json_response['messages'][0]['text']).to eq 'Purr Purr'
         end
       end
     end

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -8,10 +8,14 @@ RSpec.describe "Chatfuel", type: :request do
     end
 
     describe "/chatfuel/:topic" do
-      let(:topic_id) { 1 }
-      let(:url) { "/chatfuel/#{topic_id}" }
+      let(:topic_name) { "milk_quality" }
+      let(:url) { "/chatfuel/#{topic_name}" }
       let(:chatbot_channel)   { Channel.chatbot }
       let(:report)            { Report.current }
+
+      describe 'topic doesn\'t exist' do
+        it { is_expected.to have_http_status(404) }
+      end
 
       describe 'text component doesn\'t exist' do
         before { create(:topic, id: 1, name: "milk_quality") }

--- a/spec/requests/chatfuel_spec.rb
+++ b/spec/requests/chatfuel_spec.rb
@@ -22,6 +22,40 @@ RSpec.describe "Chatfuel", type: :request do
         it { is_expected.to have_http_status(404) }
       end
 
+      describe 'text compoent with wrong topic' do
+        let(:topic) { create(:topic, id: 2, name: "milk_quantity") }
+
+        before do
+          create(
+            :text_component,
+            report: report,
+            topic: topic,
+            channels: [chatbot_channel],
+            main_part: "The main part",
+            id: 1
+          )
+        end
+
+        it { is_expected.to have_http_status(404) }
+      end
+
+      describe 'text compoent with wrong channel' do
+        let(:topic) { create(:topic, id: 1, name: "milk_quality") }
+
+        before do
+          create(
+            :text_component,
+            report: report,
+            topic: topic,
+            channels: [Channel.sensorstory],
+            main_part: "The main part",
+            id: 1
+          )
+        end
+
+        it { is_expected.to have_http_status(404) }
+      end
+
       describe 'existing topic' do
         let(:topic) { create(:topic, id: 1, name: "milk_quality") }
 


### PR DESCRIPTION
Fixed the bug where the Chatfuel API request would always return the same text component, not looking for the requested topic.

Now the topic request looks for the topic with the corresponding topic name and returns the first text component of this topic.

---

Close #385 