### PR TITLE
358 render any markup

### DIFF
--- a/app/controllers/chatfuel_controller.rb
+++ b/app/controllers/chatfuel_controller.rb
@@ -33,11 +33,12 @@ class ChatfuelController < ApplicationController
 
   def json_response
     if @question_answer
-      content = @question_answer.answer
+      text = Text::Renderer.new(text_component: @text_component).render_string(@question_answer.answer)
     else
       text = Text::Renderer.new(text_component: @text_component).render(:main_part)
-      content = text.first(640);
     end
+
+    content = text.first(640);
 
     if @next_question_answer
       {

--- a/spec/controllers/chatfuel_controller_spec.rb
+++ b/spec/controllers/chatfuel_controller_spec.rb
@@ -25,24 +25,35 @@ RSpec.describe ChatfuelController, type: :controller do
       end
 
       context "matching text component" do
-        let(:text_component) do
-          create(
-            :text_component,
-            report: report,
-            topic: topic,
-            channels: [chatbot_channel],
-            main_part: "The main part"
-          )
+
+        context "without markup" do
+          before { create(:text_component, report: report, topic: topic, channels: [chatbot_channel], main_part: "The main part") }
+
+          it { is_expected.to have_http_status(:ok) }
+
+          it "returns expected text" do
+            json_response = JSON.parse(subject.body)
+            expect(json_response["messages"].first["text"]).to eq("The main part")
+          end
         end
 
-        before { text_component }
+        context "with markup and sensory data" do
+          let(:sensor)        { create(:sensor, name: 'SensorXY', sensor_type: sensor_type) }
+          let(:sensor_type)   { create(:sensor_type, property: 'Temperature', unit: '°C') }
 
-        it { is_expected.to have_http_status(:ok) }
+          before do
+            create(:text_component, report: report, topic: topic, channels: [chatbot_channel], main_part: "SensorXY: { value(#{sensor.id}) }")
+            create(:sensor_reading, sensor: sensor, calibrated_value: 5)
+          end
 
-        it "returns expected text" do
-          json_response = JSON.parse(subject.body)
-          expect(json_response["messages"].first["text"]).to eq("The main part")
+          it { is_expected.to have_http_status(:ok) }
+
+          it "returns text with replaced markup" do
+            json_response = JSON.parse(subject.body)
+            expect(json_response["messages"].first["text"]).to eq("SensorXY: 5.0°C")
+          end
         end
+
       end
     end
   end


### PR DESCRIPTION
Extended the chatfuel controller to render markup in questions and answers for the chatbot as well.

close #358 