### PR TITLE
default scope to define a natural ordering of question answers

### DIFF
--- a/app/models/question_answer.rb
+++ b/app/models/question_answer.rb
@@ -1,5 +1,5 @@
 class QuestionAnswer < ApplicationRecord
-  default_scope { order(created_at: :asc) }
+  default_scope { order(:created_at, :id ) }
 
   belongs_to :text_component
 

--- a/app/models/question_answer.rb
+++ b/app/models/question_answer.rb
@@ -1,4 +1,6 @@
 class QuestionAnswer < ApplicationRecord
+  default_scope { order(created_at: :asc) }
+
   belongs_to :text_component
 
   validates :question, length: { maximum: 640 }


### PR DESCRIPTION
fix #414 

@matthib @sebroeder @tillprochaska 

I enforce an order on all `QuestionAnswer`s with a default scope here. This has an effect on pretty much everything related to `QuestionAnswer`s, every call like `text_component.question_answers` will return the question answers ordered by `created_at`. `default_scope` is a source of errors and should be used with the utmost precaution. AFAIK as long as we edit all question-answers through the text component like a "stack" this should be no problem. What is your opinion on it? Do you think it's safe to use? 