### PR TITLE
443 prevent duplicate smaxtec sensor readings

### DIFF
--- a/app/lib/smaxtec_api.rb
+++ b/app/lib/smaxtec_api.rb
@@ -28,11 +28,16 @@ class SmaxtecApi
     @jwt = JSON.parse(jwt_request)['token']
     #animal_id = '5722099ea80a5f54c631513d' # name = Arabella
     temp_data = send_api_request('/data/query', { :animal_id => sensor.animal_id, :metric => metric, :from_date => Time.now.to_i - 3600, :to_date => Time.now.to_i })
+
     if temp_data && temp_data['data'].count > 1
       last_entry = temp_data['data'].last
       timestamp = last_entry[0]
-      value = last_entry[1] # WTF?
-      return Sensor::Reading.new(sensor: sensor, calibrated_value: value, uncalibrated_value: value, smaxtec_timestamp: timestamp)
+      value = last_entry[1]
+      if !Sensor::Reading.find_by(sensor_id: sensor.id, smaxtec_timestamp: timestamp)
+        return Sensor::Reading.new(sensor: sensor, calibrated_value: value, uncalibrated_value: value, smaxtec_timestamp: timestamp)
+      else
+        return nil
+      end
     else
       return nil
     end

--- a/app/lib/smaxtec_api.rb
+++ b/app/lib/smaxtec_api.rb
@@ -33,10 +33,9 @@ class SmaxtecApi
       last_entry = temp_data['data'].last
       timestamp = last_entry[0]
       value = last_entry[1]
-      if !Sensor::Reading.find_by(sensor_id: sensor.id, smaxtec_timestamp: timestamp)
-        return Sensor::Reading.new(sensor: sensor, calibrated_value: value, uncalibrated_value: value, smaxtec_timestamp: timestamp)
-      else
-        return nil
+      return Sensor::Reading.find_or_create_by(sensor_id: sensor.id, smaxtec_timestamp: timestamp) do |reading|
+        reading.calibrated_value = value
+        reading.uncalibrated_value = value
       end
     else
       return nil

--- a/app/lib/smaxtec_api.rb
+++ b/app/lib/smaxtec_api.rb
@@ -29,8 +29,10 @@ class SmaxtecApi
     #animal_id = '5722099ea80a5f54c631513d' # name = Arabella
     temp_data = send_api_request('/data/query', { :animal_id => sensor.animal_id, :metric => metric, :from_date => Time.now.to_i - 3600, :to_date => Time.now.to_i })
     if temp_data && temp_data['data'].count > 1
-      value = temp_data['data'].last[1] # WTF?
-      return Sensor::Reading.new(sensor: sensor, calibrated_value: value, uncalibrated_value: value)
+      last_entry = temp_data['data'].last
+      timestamp = last_entry[0]
+      value = last_entry[1] # WTF?
+      return Sensor::Reading.new(sensor: sensor, calibrated_value: value, uncalibrated_value: value, smaxtec_timestamp: timestamp)
     else
       return nil
     end

--- a/db/migrate/20170625165032_add_smaxtec_timestamp_to_sensor_readings.rb
+++ b/db/migrate/20170625165032_add_smaxtec_timestamp_to_sensor_readings.rb
@@ -1,0 +1,5 @@
+class AddSmaxtecTimestampToSensorReadings < ActiveRecord::Migration[5.0]
+  def change
+    add_column :sensor_readings, :smaxtec_timestamp, :timestamp
+  end
+end

--- a/db/migrate/20170625170112_add_smaxtec_timestamp_to_sensor_readings.rb
+++ b/db/migrate/20170625170112_add_smaxtec_timestamp_to_sensor_readings.rb
@@ -1,5 +1,5 @@
 class AddSmaxtecTimestampToSensorReadings < ActiveRecord::Migration[5.0]
   def change
-    add_column :sensor_readings, :smaxtec_timestamp, :timestamp
+    add_column :sensor_readings, :smaxtec_timestamp, :bigint
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170625165032) do
+ActiveRecord::Schema.define(version: 20170625170112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,7 +120,7 @@ ActiveRecord::Schema.define(version: 20170625165032) do
     t.datetime "updated_at",                     null: false
     t.integer  "sensor_id"
     t.integer  "intention",          default: 0
-    t.datetime "smaxtec_timestamp"
+    t.bigint   "smaxtec_timestamp"
     t.index ["sensor_id"], name: "index_sensor_readings_on_sensor_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 20170625170112) do
     t.float    "max_value"
     t.float    "min_value"
     t.datetime "calibrated_at"
+    t.boolean  "smaxtec_sensor"
     t.string   "animal_id"
     t.index ["address"], name: "index_sensors_on_address", unique: true, using: :btree
     t.index ["name"], name: "index_sensors_on_name", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622145518) do
+ActiveRecord::Schema.define(version: 20170625165032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,7 @@ ActiveRecord::Schema.define(version: 20170622145518) do
     t.datetime "updated_at",                     null: false
     t.integer  "sensor_id"
     t.integer  "intention",          default: 0
+    t.datetime "smaxtec_timestamp"
     t.index ["sensor_id"], name: "index_sensor_readings_on_sensor_id", using: :btree
   end
 
@@ -141,7 +142,6 @@ ActiveRecord::Schema.define(version: 20170622145518) do
     t.float    "max_value"
     t.float    "min_value"
     t.datetime "calibrated_at"
-    t.boolean  "smaxtec_sensor"
     t.string   "animal_id"
     t.index ["address"], name: "index_sensors_on_address", unique: true, using: :btree
     t.index ["name"], name: "index_sensors_on_name", unique: true, using: :btree

--- a/spec/lib/smaxtec_api_spec.rb
+++ b/spec/lib/smaxtec_api_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe SmaxtecApi do
       end
     end
   end
+
+  describe '.update_sensor_readings' do
+
+    it 'should not create a sensor reading if the sensor reading for the specific sensor type already exists' do
+      sensor # create
+      VCR.use_cassette('smaxtec_api', :record => :once) do
+        expect { smaxtec_api.update_sensor_readings }.to change {Sensor::Reading.count}.from(0).to(1)
+      end
+
+      VCR.use_cassette('smaxtec_api', :record => :once) do
+        expect { smaxtec_api.update_sensor_readings }.to_not change {Sensor::Reading.count}
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prevent duplicate smaxtec sensor readings by adding smaxtec_timestamp to sensor reading table & check if combination of smactec_timestamp and sensor_id already exists before creating new sensor reading.

---
Close #443 