### PR TITLE
added ph value and movement to sensor types

### DIFF
--- a/app/lib/smaxtec_api.rb
+++ b/app/lib/smaxtec_api.rb
@@ -4,7 +4,7 @@ class SmaxtecApi
   SMAXTEC_API_EMAIL = Rails.application.secrets.smaxtec_api_email
   SMAXTEC_API_PASSWORD = Rails.application.secrets.smaxtec_api_password
   SMAXTEC_API_BASE_URL = 'https://api-staging.smaxtec.com/api/v1'
-  PROPERTY_MAPPING = {'Temperature' => 'temp'}
+  PROPERTY_MAPPING = {'Temperature' => 'temp', 'pH Value' => 'ph', 'Movement' => 'act'}
 
   def update_sensor_readings
     abort("missing SMAXTEC_API_EMAIL and SMAXTEC_API_PASSWORD") unless SMAXTEC_API_PASSWORD && SMAXTEC_API_PASSWORD

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,9 @@ attribute_hashes = [
   { property: 'Zeit'              , unit: 'hours'                                        },
   { property: 'Milchmenge'        , unit: 'kg'                                           },
   { property: 'Lautstärke'        , unit: '0-10 - still, leise, mittel, laut, sehr laut' },
-  { property: 'Favs'              , unit: '0-unlimited'                                  }
+  { property: 'Favs'              , unit: '0-unlimited'                                  },
+  { property: 'pH Value'          , unit: 'pH'                                           },
+  { property: 'Movement'          , unit: '1-100'                                        }
 ]
 
 new_sensor_types = attribute_hashes.collect{ |attributes| SensorType.new attributes }


### PR DESCRIPTION
This commit adds the sensor types for ph Value und and movement together with their Smaxtec API equivalents.

I was not 100% about the Smaxtec value for movement, but I think it is act which stands for activity probably. There is also the value act_index which seems to also be an activity index, but act_index is measured in percent and act is measured metrically.
@drjakob Should I double check which is the right value with the Smaxtec guys?

Also when digging through the data of the different cows I found out that not every cow has the same metrics / data available at their sensors. Some don't have ph value and some don't have a movement value available, so it might happen that we don't get all the metrics from all the cows.

---
Close #393 
Close #392 