### PR TITLE
Add sensor types & change movement smaxtec mapping metric

### DIFF
--- a/app/lib/smaxtec_api.rb
+++ b/app/lib/smaxtec_api.rb
@@ -5,7 +5,7 @@ class SmaxtecApi
   SMAXTEC_API_EMAIL = Rails.application.secrets.smaxtec_api_email
   SMAXTEC_API_PASSWORD = Rails.application.secrets.smaxtec_api_password
   SMAXTEC_API_BASE_URL = 'https://api-staging.smaxtec.com/api/v1'
-  PROPERTY_MAPPING = {'Temperature' => 'temp', 'pH Value' => 'ph', 'Movement' => 'act'}
+  PROPERTY_MAPPING = {'Temperature' => 'temp', 'pH Value' => 'ph', 'Movement' => 'act_index'}
 
   def update_sensor_readings
     puts "[" + Time.now.to_s + "] " + "Started update_sensor_readings"

--- a/lib/tasks/smaxtec_api.rake
+++ b/lib/tasks/smaxtec_api.rake
@@ -5,7 +5,7 @@ namespace :smaxtec_api do
     smaxtec_api_controller.update_sensor_readings
   end
 
-  desc "add smaxtec readings"
+  desc "add smaxtec sensortypes"
   task add_smaxtec_sensortypes: :environment do
     SensorType.find_or_create_by(property: 'pH Value', unit: 'pH')
     SensorType.find_or_create_by(property: 'Movement', unit: '1-100')

--- a/lib/tasks/smaxtec_api.rake
+++ b/lib/tasks/smaxtec_api.rake
@@ -4,4 +4,10 @@ namespace :smaxtec_api do
     smaxtec_api_controller = SmaxtecApi.new
     smaxtec_api_controller.update_sensor_readings
   end
+
+  desc "add smaxtec readings"
+  task add_smaxtec_sensortypes: :environment do
+    SensorType.find_or_create_by(property: 'pH Value', unit: 'pH')
+    SensorType.find_or_create_by(property: 'Movement', unit: '1-100')
+  end
 end


### PR DESCRIPTION
I added the smaxtec sensortype via rake task 'smaxtec_api:add_smaxtec_sensortypes' and changed the smaxtec sensor metric mapping for the movement sensor to 'act_index' (-> 'act' activity value smoothed and stretched from 0-100 in %).

---

Close #459 