### PR TITLE
SensorType: default order

### DIFF
--- a/app/models/sensor_type.rb
+++ b/app/models/sensor_type.rb
@@ -1,2 +1,3 @@
 class SensorType < ActiveRecord::Base
+  default_scope { order(:property) }
 end


### PR DESCRIPTION
This will e.g. order SensorTypes in the Sensor#edit form by property. A default scope has global effect, but I think it's safe to use as long it's just the `order`.