### PR TITLE
460 wrong report id in diaries controller

### DIFF
--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -9,22 +9,26 @@ class DiaryEntriesController < ApplicationController
   end
 
   private
-    def set_diary_entry
-      @diary_entry = DiaryEntry.find(params[:id])
-    end
+  def diary_entries
+    DiaryEntry.where(report: @report).order(:moment)
+  end
 
-    def filter_diary_entries
-      @diary_entries = DiaryEntry.all
-      if filter_params[:intention]
-        @diary_entries = @diary_entries.where(intention: filter_params[:intention])
-      end
-      if filter_params[:from] && filter_params[:to]
-        @diary_entries = @diary_entries.where('moment > ?',  filter_params[:from])
-        @diary_entries = @diary_entries.where('moment < ?',  filter_params[:to])
-      end
-    end
+  def set_diary_entry
+    @diary_entry = DiaryEntry.find(params[:id])
+  end
 
-    def filter_params
-      params.permit(:from, :to, :intention)
+  def filter_diary_entries
+    @diary_entries = diary_entries
+    if filter_params[:intention]
+      @diary_entries = @diary_entries.where(intention: filter_params[:intention])
     end
+    if filter_params[:from] && filter_params[:to]
+      @diary_entries = @diary_entries.where('moment > ?',  filter_params[:from])
+      @diary_entries = @diary_entries.where('moment < ?',  filter_params[:to])
+    end
+  end
+
+  def filter_params
+    params.permit(:from, :to, :intention)
+  end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -15,14 +15,14 @@ class ReportsController < ApplicationController
 
   def present
     @live_entry = DiaryEntry.new(report: @report, intention: :real, moment: query_params[:point_in_time]).compose
-    @archived_entries = DiaryEntry.real.order(:created_at).reverse_order.collect do |entry|
+    @diary_entries = DiaryEntry.real.order(:created_at).reverse_order.collect do |entry|
       entry.compose
     end
   end
 
   def preview
     @live_entry = DiaryEntry.new(report: @report, intention: :fake, moment: query_params[:point_in_time]).compose
-    @archived_entries = DiaryEntry.fake.order(:created_at).reverse_order.collect do |entry|
+    @diary_entries = DiaryEntry.fake.order(:created_at).reverse_order.collect do |entry|
       entry.compose
     end
     render 'present'

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -15,14 +15,14 @@ class ReportsController < ApplicationController
 
   def present
     @live_entry = DiaryEntry.new(report: @report, intention: :real, moment: query_params[:point_in_time]).compose
-    @diary_entries = DiaryEntry.real.order(:created_at).reverse_order.collect do |entry|
+    @diary_entries = diary_entries.real.collect do |entry|
       entry.compose
     end
   end
 
   def preview
     @live_entry = DiaryEntry.new(report: @report, intention: :fake, moment: query_params[:point_in_time]).compose
-    @diary_entries = DiaryEntry.fake.order(:created_at).reverse_order.collect do |entry|
+    @diary_entries = diary_entries.fake.collect do |entry|
       entry.compose
     end
     render 'present'
@@ -45,6 +45,10 @@ class ReportsController < ApplicationController
       result[:point_in_time] = DateTime.now
     end
     result
+  end
+
+  def diary_entries
+    DiaryEntry.where(report: @report).order(:moment).reverse_order
   end
 
   def report_params

--- a/app/lib/text/generator.rb
+++ b/app/lib/text/generator.rb
@@ -45,9 +45,7 @@ module Text
               diary_entry: @diary_entry
             }
           )
-
         end
-
 
         result += ApplicationController.render(
           partial: 'diary_entries/split_part',

--- a/app/lib/text/generator.rb
+++ b/app/lib/text/generator.rb
@@ -2,10 +2,6 @@ module Text
   class Generator
     BREAK_AFTER = 500 # characters
 
-    def report
-      @diary_entry.report
-    end
-
     def initialize(diary_entry)
       @diary_entry = diary_entry
     end

--- a/app/views/reports/present.html.haml
+++ b/app/views/reports/present.html.haml
@@ -7,6 +7,6 @@
     %iframe{width: 640, height: 360, src: @report.video, frameborder: 0, type: 'text/html'}
   = render @live_entry
 
-- @archived_entries.each do |ar|
+- @diary_entries.each do |ar|
   .archived-report
     = render ar

--- a/lib/tasks/archive.rake
+++ b/lib/tasks/archive.rake
@@ -1,12 +1,16 @@
 namespace :archive do
   desc "Archive current report"
   task :real => :environment do
-    DiaryEntry.new(report: Report.current, intention: :real).archive!
+    Report.find_each do |report|
+      DiaryEntry.new(report: report, intention: :real).archive!
+    end
   end
 
   desc "Archive current preview"
   task :fake => :environment do
-    DiaryEntry.new(report: Report.current, intention: :fake).archive!
+    Report.find_each do |report|
+      DiaryEntry.new(report: report, intention: :fake).archive!
+    end
   end
 end
 

--- a/spec/controllers/diary_entries_controller_spec.rb
+++ b/spec/controllers/diary_entries_controller_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe DiaryEntriesController, type: :controller do
       get :index, params: params, session: valid_session
       expect(assigns(:diary_entries)).to eq([diary_entry])
     end
+
+    it "assigns the diary entries that belong to the report" do
+      report = create(:report)
+      expected = create(:diary_entry, report: report)
+      not_expected = create(:diary_entry)
+      get :index, params: {report_id: report.id}
+      diary_entries = assigns(:diary_entries)
+      expect(diary_entries).to include(expected)
+      expect(diary_entries).not_to include(not_expected)
+    end
   end
 
   describe "GET #show" do

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ReportsController, type: :controller do
     it 'assigns the correct report' do
       create(:report, id: 42)
       get :show, params: { report_id: 42 }
-      expect(assigns(:report).id).to eq 42
     end
   end
 
@@ -32,6 +31,16 @@ RSpec.describe ReportsController, type: :controller do
       expect(Report.current.id).to eq 1
       get :present, params: {report_id: 1}
       expect(response).to render_template :present
+    end
+
+    it "assigns the diary entries that belong to the report" do
+      report = create(:report)
+      expected = create(:diary_entry, report: report)
+      not_expected = create(:diary_entry)
+      get :present, params: {report_id: report.id}
+      diary_entries = assigns(:diary_entries)
+      expect(diary_entries).to include(expected)
+      expect(diary_entries).not_to include(not_expected)
     end
   end
 end


### PR DESCRIPTION
That was a nice bug :bug: 

Diary entries at the `diary_entries/` route as well as on the landing page did not belong to the given `@report`. It was the first report instead. Also the `rake` task never produced any other diary entries except those for the first report
