### PR TITLE
change url of smaxtec api to use live api

### DIFF
--- a/app/lib/smaxtec_api.rb
+++ b/app/lib/smaxtec_api.rb
@@ -4,7 +4,7 @@ class SmaxtecApi
 
   SMAXTEC_API_EMAIL = Rails.application.secrets.smaxtec_api_email
   SMAXTEC_API_PASSWORD = Rails.application.secrets.smaxtec_api_password
-  SMAXTEC_API_BASE_URL = 'https://api-staging.smaxtec.com/api/v1'
+  SMAXTEC_API_BASE_URL = 'https://api.smaxtec.com/api/v1'
   PROPERTY_MAPPING = {'Temperature' => 'temp', 'pH Value' => 'ph', 'Movement' => 'act_index'}
 
   def update_sensor_readings

--- a/fixtures/vcr_cassettes/smaxtec_api.yml
+++ b/fixtures/vcr_cassettes/smaxtec_api.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api-staging.smaxtec.com/api/v1/user/get_token?email=superkuh@hooli.xyz&password=pansen123
+    uri: https://api.smaxtec.com/api/v1/user/get_token?email=superkuh@hooli.xyz&password=pansen123
     body:
       encoding: US-ASCII
       string: ''
@@ -43,7 +43,7 @@ http_interactions:
   recorded_at: Wed, 05 Jul 2017 17:57:45 GMT
 - request:
     method: get
-    uri: https://api-staging.smaxtec.com/api/v1/data/query?animal_id=5722099ea80a5f54c631513d&from_date=1499234265&metric=temp&to_date=1499277465
+    uri: https://api.smaxtec.com/api/v1/data/query?animal_id=5722099ea80a5f54c631513d&from_date=1499234265&metric=temp&to_date=1499277465
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Use Smaxtec Live API endpoint by changing the url the system is sending queries to update the sensory data to.

---

Close #467 