### PR TITLE
470 allow cors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'bootstrap', git: 'https://github.com/twbs/bootstrap-rubygem'
 gem 'haml-rails'
 gem 'simple_form'
 gem 'cocoon'
+gem 'rack-cors', :require => 'rack/cors'
 gem 'whenever', :require => false
 gem 'bootstrap-slider-rails'
 gem 'bootstrap-select-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,7 @@ GEM
     public_suffix (2.0.5)
     puma (3.8.1)
     rack (2.0.1)
+    rack-cors (1.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.2)
@@ -404,6 +405,7 @@ DEPENDENCIES
   poltergeist
   pry
   puma
+  rack-cors
   rails (~> 5.0)
   rails-controller-testing
   rails-erd

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,13 @@ module StoryBoard
     config.autoload_paths += %W(#{config.root}/lib/)
 
     config.generators.helper = false
+
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', :headers => :any, :methods => [:get, :post, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
close #470 

On my machine, this is what `curl -H "Origin:*" -I http://localhost:3000/` gives me:

```
HTTP/1.1 301 Moved Permanently
Access-Control-Allow-Origin: *
Access-Control-Allow-Methods: GET, POST, OPTIONS
Access-Control-Max-Age: 1728000
Location: http://localhost:3000/reports/current
Content-Type: text/html
Cache-Control: no-cache
X-Request-Id: a635f5a4-03dd-4e11-9a29-0d2cdeb188fb
X-Runtime: 0.005417
Vary: Origin
Content-Length: 103
```

@davidLichtenberger do you need any more HTTP methods like `PUT`, `PATCH`, `DELETE`?