### PR TITLE
Added destroy and reinit methods to Range component

### DIFF
--- a/app/assets/javascripts/components/range.js
+++ b/app/assets/javascripts/components/range.js
@@ -28,7 +28,11 @@ var Range = (function($, multirange) {
             min: this.$elm.data('min') || 0,
             max: this.$elm.data('max') || 100,
             step: this.$elm.data('step') || 1,
+
             value: [this.$min.val() || 0, this.$max.val() || 100].sort(),
+            valueFormatter: function(value) {
+                return value;
+            }
         }
 
         // extend default options
@@ -52,8 +56,8 @@ var Range = (function($, multirange) {
         });
 
         // create range min/max info elements
-        $infoMin = $('<span>').addClass('range__info range__info--min').text(self.options.min);
-        $infoMax = $('<span>').addClass('range__info range__info--max').text(self.options.max);
+        $infoMin = $('<span>').addClass('range__info range__info--min').text(self.options.valueFormatter(self.options.min));
+        $infoMax = $('<span>').addClass('range__info range__info--max').text(self.options.valueFormatter(self.options.max));
 
         // create value tooltips
         var $tooltipLow = $('<div>').addClass('range__tooltip');
@@ -117,12 +121,13 @@ var Range = (function($, multirange) {
         self.$tooltipLow.css({
             'left': lowLeft * 100 + '%',
             'marginLeft' : (lowLeft - .5) / -.5 * rangeThumb,
-        }).text(low);
+        }).text(self.options.valueFormatter(low));
+
         self.$tooltipHigh.css({
             'left': highLeft * 100 + '%',
             'marginLeft' : (highLeft - .5) / -.5 * rangeThumb,
 
-        }).text(high);
+        }).text(self.options.valueFormatter(high));
 
         return this;
     }

--- a/app/assets/stylesheets/components/_range.scss
+++ b/app/assets/stylesheets/components/_range.scss
@@ -34,6 +34,7 @@
     padding: .125em .5em;
 
     font-size: .8em;
+    white-space: nowrap;
     background-color: $brand-primary;
     color: #fff;
     border-radius: 3px;


### PR DESCRIPTION
@roschaefer: You can now reinitialize the range slider at any time.

```javascript
$('.selector').data('range').reinit({
  min: -10,
  max: -5,
  step: .1
})
```

This will keep the rangeslider’s value or set it to the new min/max value if it doesn’t lie in the value range.

Of course you can also set a new value in the same go:

```javascript
$('.selector').data('range').reinit({
  min: -10,
  max: -5,
  step: .1
}).value('-9,-6')
```

And you can also completely reset the slider to restore the initial state (which is what the `reinit` method uses internally):

```javascript
$('.selector').data('range').destroy()
```