### PR TITLE
close #384

### DIFF
--- a/app/decorators/sensor_decorator.rb
+++ b/app/decorators/sensor_decorator.rb
@@ -10,7 +10,7 @@ class SensorDecorator
 
     if r
       v = r.calibrated_value
-      "#{format("%.1f", v)}#{u}"
+      "#{format("%.1f", v)} #{u}"
     else
       "-- missing sensory data --"
     end

--- a/features/triggers/write_about_sensor_value.feature
+++ b/features/triggers/write_about_sensor_value.feature
@@ -27,9 +27,9 @@ Feature: Write about the actual sensor value
     When I visit the landing page
     Then I should see:
     """
-    Wow, it's incredible 32.0°C!
+    Wow, it's incredible 32.0 °C!
     """
     And I should see:
     """
-    Take your sunglasses: 85000.0Lux outside!
+    Take your sunglasses: 85000.0 Lux outside!
     """

--- a/spec/controllers/chatfuel_controller_spec.rb
+++ b/spec/controllers/chatfuel_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe ChatfuelController, type: :controller do
 
           it "returns text with replaced markup" do
             json_response = JSON.parse(subject.body)
-            expect(json_response["messages"].first["text"]).to eq("SensorXY: 5.0°C")
+            expect(json_response["messages"].first["text"]).to eq("SensorXY: 5.0 °C")
           end
         end
 

--- a/spec/decorators/sensor_decorator_spec.rb
+++ b/spec/decorators/sensor_decorator_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe SensorDecorator do
 
       context 'release :final' do
         subject { super().last_value }
-        it { is_expected.to eq '5.0°C'}
+        it { is_expected.to eq '5.0 °C'}
       end
 
       context 'release :debug' do
         subject { super().last_value(DiaryEntry.new(release: :debug)) }
-        it { is_expected.to eq '-3.0°C'}
+        it { is_expected.to eq '-3.0 °C'}
       end
 
     end

--- a/spec/text/generator_spec.rb
+++ b/spec/text/generator_spec.rb
@@ -245,18 +245,18 @@ RSpec.describe Text::Generator do
               context 'with markup for sensor' do
                 let(:sensor)         { create(:sensor, id: 42, name: 'SensorXY', sensor_type: sensor_type) }
                 let(:main_part)      { 'Sensor value: { value(42) }' }
-                specify { expect(subject[:main_part]).to include('Sensor value: 5.0°C') }
+                specify { expect(subject[:main_part]).to include('Sensor value: 5.0 °C') }
                 context 'but with sensor data of different release' do
                   before { reading; create(:sensor_reading, sensor: sensor, release: :debug, calibrated_value: 0) }
 
                   context 'render :debug report' do
                     let(:release) { :debug }
-                    specify { expect(subject[:main_part]).to include('Sensor value: 0.0°C') }
+                    specify { expect(subject[:main_part]).to include('Sensor value: 0.0 °C') }
                   end
 
                   context 'render :final report' do
                     let(:release) { :final }
-                    specify { expect(subject[:main_part]).to include('Sensor value: 5.0°C') }
+                    specify { expect(subject[:main_part]).to include('Sensor value: 5.0 °C') }
                   end
                 end
               end

--- a/spec/text/renderer_spec.rb
+++ b/spec/text/renderer_spec.rb
@@ -73,18 +73,18 @@ RSpec.describe Text::Renderer do
             context 'with markup for sensor' do
               let(:sensor)         { create(:sensor, id: 42, name: 'SensorXY', sensor_type: sensor_type) }
               let(:main_part)      { 'Sensor value: { value(42) }' }
-              it('renders sensor value') { is_expected.to eq('Sensor value: 5.0°C')}
+              it('renders sensor value') { is_expected.to eq('Sensor value: 5.0 °C')}
               context 'but with sensor data of different release' do
                 before { reading; create(:sensor_reading, sensor: sensor, release: :debug, calibrated_value: 0) }
 
                 context 'render :debug report' do
                   let(:release) { :debug }
-                  it { is_expected.to eq('Sensor value: 0.0°C')}
+                  it { is_expected.to eq('Sensor value: 0.0 °C')}
                 end
 
                 context 'render :final report' do
                   let(:release) { :final }
-                  it { is_expected.to eq('Sensor value: 5.0°C')}
+                  it { is_expected.to eq('Sensor value: 5.0 °C')}
                 end
               end
             end


### PR DESCRIPTION
close #384

@tillprochaska after I've seen the types of units, I would suggest to always put a space between value and unit to have a clear separation.