### PR TITLE
421 sensory data fallback

### DIFF
--- a/app/assets/stylesheets/components/_field.scss
+++ b/app/assets/stylesheets/components/_field.scss
@@ -51,7 +51,7 @@
     transform: translate(-50%, -100%);
     z-index: 3;
     display: none;
-    margin-top: -6px;
+    margin-top: -10px;
     padding: .2em .5em;
 
     background: #000;

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -9,7 +9,7 @@ class EventDecorator
     
     if date
       date.in_time_zone(Report::TIME_ZONE).strftime(Report::DATE_FORMAT)
-    elsif
+    elsif fallback
       fallback
     else
       "-- missing event data --"

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -4,11 +4,13 @@ class EventDecorator
     @event = event
   end
 
-  def date
+  def date(fallback = nil)
     date = @event.happened_at
     
     if date
       date.in_time_zone(Report::TIME_ZONE).strftime(Report::DATE_FORMAT)
+    elsif
+      fallback
     else
       "-- missing event data --"
     end

--- a/app/decorators/sensor_decorator.rb
+++ b/app/decorators/sensor_decorator.rb
@@ -4,13 +4,15 @@ class SensorDecorator
     @sensor = sensor
   end
 
-  def last_value(diary_entry = nil)
+  def last_value(diary_entry = nil, fallback = nil)
     r = @sensor.last_reading(diary_entry)
     u = @sensor.sensor_type.unit
 
     if r
       v = r.calibrated_value
       "#{format("%.1f", v)} #{u}"
+    elsif fallback
+      fallback
     else
       "-- missing sensory data --"
     end

--- a/app/lib/text/renderer.rb
+++ b/app/lib/text/renderer.rb
@@ -28,7 +28,7 @@ module Text
 
         end
 
-        event_markup = rendered.scan(/{\s*date\(\s*(\d+)\s*\)\s*}/).flatten
+        event_markup = rendered.scan(/{\s?date\(\s?(\d+)\s?\)(?:\s?\|\s?".*")?\s?}/).flatten
         Event.where(:id => event_markup).each do |event|
           e = EventDecorator.new(event)
 

--- a/app/views/question_answers/_fields.html.haml
+++ b/app/views/question_answers/_fields.html.haml
@@ -1,21 +1,7 @@
 .nested-fields.qa__item.form-group
   .text-editor{data: {'editor-data': {sensors: @sensors.map{ |s| [s.id, s.name]}.to_h, events: @events.map{ |e| [e.id, e.name] }.to_h }.to_json }}
     .text-editor__toolbar
-      .text-editor__toolbar__item
-        Sensors
-        %select{'data-editor-markup-select': true}
-          %option{disabled: true, selected: true} Please select a sensor
-          - @sensors.each do |sensor|
-            %option{data: {editor: {'markup-command': 'text', 'markup-text': "{value(#{sensor.id})}"}}}
-              = sensor.name
-      .text-editor__toolbar__item
-        Events
-        %select{'data-editor-markup-select': true}
-          %option{disabled: true, selected: true} Please select an event
-          - @events.each do |event|
-            %option{data: {editor: {'markup-command': 'text', 'markup-text': "{date(#{event.id})}"}}}
-              = event.name
-
+      = render 'shared/text_editor/toolbar_buttons', sensors: @sensors, events: @events
       .text-editor__toolbar__item.text-editor__toolbar__item--destroy
         = link_to_remove_association 'Remove Q/A', f, {class: 'text-danger'}
     

--- a/app/views/shared/text_editor/_toolbar_buttons.html.haml
+++ b/app/views/shared/text_editor/_toolbar_buttons.html.haml
@@ -1,0 +1,14 @@
+.text-editor__toolbar__item
+  Sensors
+  %select{'data-editor-markup-select': true}
+    %option{disabled: true, selected: true} Please select a sensor
+    - sensors.each do |sensor|
+      %option{data: {editor: {'markup-command': 'sensor', 'markup-sensor': sensor.id}}}
+        = sensor.name
+.text-editor__toolbar__item
+  Events
+  %select{'data-editor-markup-select': true}
+    %option{disabled: true, selected: true} Please select an event
+    - events.each do |event|
+      %option{data: {editor: {'markup-command': 'event', 'markup-event': event.id}}}
+        = event.name

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -67,21 +67,9 @@
 
       .form__section__body
         .text-editor{data: {'editor-data': {sensors: @sensors.map{ |s| [s.id, s.name]}.to_h, events: @events.map{ |e| [e.id, e.name] }.to_h }.to_json }}
+
           .text-editor__toolbar
-            .text-editor__toolbar__item
-              Sensors
-              %select{'data-editor-markup-select': true}
-                %option{disabled: true, selected: true} Please select a sensor
-                - @sensors.each do |sensor|
-                  %option{data: {editor: {'markup-command': 'text', 'markup-text': "{value(#{sensor.id})}"}}}
-                    = sensor.name
-            .text-editor__toolbar__item
-              Events
-              %select{'data-editor-markup-select': true}
-                %option{disabled: true, selected: true} Please select an event
-                - @events.each do |event|
-                  %option{data: {editor: {'markup-command': 'text', 'markup-text': "{date(#{event.id})}"}}}
-                    = event.name
+            = render 'shared/text_editor/toolbar_buttons', sensors: @sensors, events: @events
 
           .text-editor__fields
             .field.text-editor__field

--- a/spec/text/renderer_spec.rb
+++ b/spec/text/renderer_spec.rb
@@ -99,6 +99,23 @@ RSpec.describe Text::Renderer do
               end
             end
           end
+
+          context 'without sensor data' do
+            before { report }
+
+            context 'with markup for sensor' do
+
+              context 'with fallback content' do
+                let(:sensor)    { create(:sensor, id: 42, name: 'SensorXY', sensor_type: sensor_type) }
+                let(:main_part) { 'Sensor value: { value(42) | "Fallback" }' }
+
+                it('renders the fallback content') { is_expected.to eq('Sensor value: Fallback') }
+              end
+
+            end
+
+          end
+
         end
       end
     end

--- a/spec/text/renderer_spec.rb
+++ b/spec/text/renderer_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe Text::Renderer do
               end
             end
           end
+
+          context 'has not happened' do
+            context 'with a fallback value' do
+              let(:main_part) { 'Day of your death: { date(42) | "We will see…" }' }
+
+              it 'renders the fallback value' do
+                is_expected.to eq('Day of your death: We will see…')
+              end
+            end
+          end
+
         end
 
         context 'given a condition' do


### PR DESCRIPTION
The text renderer now supports optional fallback values for both the sensor and event markup:

```
The value of the sensor is { value(123) | "currently not availbale" }.
```

I also made some minor changes:

- Tooltip position in text editor at cursor position
- The render won’t match markup that has lots of whitespace in it anymore, e. g. `{ value(123) }` and `{ value(123) | "Fallback" }` but not `{  value(123)   }` or `{ value( 123) | "Fallback" }`

@drjakob: The text editor will now ask users for a fallback value when using the sensor and event buttons. Wether this is a good solution for your workflow depends a bit on wether fallback values should be used in most cases or only in a few cases.

@roschaefer: Btw, the the test setup for events is a bit scary… ;)

![text_editor_fallback 1](https://user-images.githubusercontent.com/1512805/28527266-50e42eae-708a-11e7-98df-f0d8a611ff9f.gif)

close #421 