### PR TITLE
Larger textarea for main content in tc form

### DIFF
--- a/app/assets/stylesheets/components/_field.scss
+++ b/app/assets/stylesheets/components/_field.scss
@@ -18,13 +18,17 @@
 }
 
 .field__input, .field__mirror {
-    min-height: 5.75rem;
+    min-height: 2rem + .75rem + 2 * $line-height-base;
     padding: .75rem;
     padding-top: 2rem;
 
-    line-height: 1.5 * $font-size-base;
+    line-height: $line-height-base;
 
     border: none;
+}
+
+.field__input--large {
+    min-height: 2rem + .75rem + 8 * $line-height-base;
 }
 
 .field__input, .field__input:focus {

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -92,7 +92,7 @@
               = f.input :introduction, as: :text, :label => false, input_html: {class: 'field__input'}
             .field.text-editor__field
               .field__label Main Part
-              = f.input :main_part, as: :text, :label => false, input_html: {class: 'field__input'}
+              = f.input :main_part, as: :text, :label => false, input_html: {class: 'field__input field__input--large'}
             .field.text-editor__field
               .field__label Closing
               = f.input :closing, as: :text, :label => false, input_html: {class: 'field__input'}


### PR DESCRIPTION
@drjakob: Okay, I made the main input larger by default. Maybe that’s already enough. Setting it to 8 lines makes the form unecessary long and in the consequence harder to scan, though. Maybe something like this could help to give a quick visual impression of the text fields while still keeping the form short.

<img width="481" alt="bildschirmfoto 2017-07-24 um 19 51 01" src="https://user-images.githubusercontent.com/1512805/28536926-78b2923a-70a9-11e7-8448-62f3f14ebab6.png">

And if your editors are looking for an indicator of text length, a character/word count might be a better idea instead (and is btw pretty cheap to implement).

<img width="489" alt="bildschirmfoto 2017-07-24 um 19 48 26" src="https://user-images.githubusercontent.com/1512805/28536862-394dda5a-70a9-11e7-8df1-cdff33bc159f.png">

close #491  