### PR TITLE
removed presence validation for sensor address field

### DIFF
--- a/app/models/sensor.rb
+++ b/app/models/sensor.rb
@@ -13,7 +13,7 @@ class Sensor < ActiveRecord::Base
 
   validates :report, presence: true
   validates :name, presence: true, uniqueness: true
-  validates :address, presence: true, uniqueness: true
+  validates :address, uniqueness: true
   validates :sensor_type, presence: true
   validates :animal_id, uniqueness: { scope: :sensor_type }
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170719205918) do
+ActiveRecord::Schema.define(version: 20170724152345) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,6 +163,7 @@ ActiveRecord::Schema.define(version: 20170719205918) do
     t.integer  "publication_status", default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text     "notes"
     t.index ["assignee_id"], name: "index_text_components_on_assignee_id", using: :btree
     t.index ["report_id"], name: "index_text_components_on_report_id", using: :btree
   end


### PR DESCRIPTION
The address field of a sensor is no longer required, but still validated as unique.
Is this what you hand in mind @roschaefer?

---
Close #449 