### PR TITLE
[WIP]  Improved input fields for manual sensor inputs

### DIFF
--- a/app/assets/javascripts/sensors.coffee
+++ b/app/assets/javascripts/sensors.coffee
@@ -13,5 +13,13 @@ ready = ->
     $('#unhide_sensor_reading_form').hide()
     $('#sensor_reading_form').show()
 
+  $('#sensor_reading_day, #sensor_reading_month, #sensor_reading_year, #sensor_reading_hour, #sensor_reading_minute, #sensor_reading_second').on "change", ->
+    update_created_at()
+
+
+
+update_created_at =  ->
+  $('#sensor_reading_created_at').val($('#sensor_reading_year').val() + "-" + $('#sensor_reading_month').val() + "-" + $('#sensor_reading_day').val() + " " + $('#sensor_reading_hour').val() + ":" + $('#sensor_reading_minute').val() + ":" + $('#sensor_reading_second').val())
+
 $(document).ready(ready)
 $(document).on('page:load', ready)

--- a/app/assets/javascripts/sensors.coffee
+++ b/app/assets/javascripts/sensors.coffee
@@ -13,13 +13,5 @@ ready = ->
     $('#unhide_sensor_reading_form').hide()
     $('#sensor_reading_form').show()
 
-  $('#sensor_reading_day, #sensor_reading_month, #sensor_reading_year, #sensor_reading_hour, #sensor_reading_minute, #sensor_reading_second').on "change", ->
-    update_created_at()
-
-
-
-update_created_at =  ->
-  $('#sensor_reading_created_at').val($('#sensor_reading_year').val() + "-" + $('#sensor_reading_month').val() + "-" + $('#sensor_reading_day').val() + " " + $('#sensor_reading_hour').val() + ":" + $('#sensor_reading_minute').val() + ":" + $('#sensor_reading_second').val())
-
 $(document).ready(ready)
 $(document).on('page:load', ready)

--- a/app/controllers/sensor_readings_controller.rb
+++ b/app/controllers/sensor_readings_controller.rb
@@ -8,6 +8,7 @@ class SensorReadingsController < ApplicationController
         format.json { render json: @sensor_reading, status: :accepted }
       else
         if @sensor_reading.save
+          format.js { render 'sensor/readings/create' }
           format.json { render json: @sensor_reading, status: :created, location: @sensor_reading }
         else
           format.json { render json: @sensor_reading.errors, status: :unprocessable_entity }

--- a/app/views/sensor/readings/create.js.erb
+++ b/app/views/sensor/readings/create.js.erb
@@ -1,0 +1,1 @@
+$("<%= escape_javascript(render @sensor_reading) %>").appendTo("#sensor-readings-table-final");

--- a/app/views/sensors/_add_sensor_reading.haml
+++ b/app/views/sensors/_add_sensor_reading.haml
@@ -4,10 +4,24 @@
   %h4 Add Sensor Reading manually
   = fields_for :sensor_reading do |f|
     = f.hidden_field :sensor_id, :value => @sensor.id
-    = f.label :created_at, "Created at"
-    = f.text_field :created_at, placeholder: 'YYYY-MM-DD HH-MM-SS'
+    = f.label :created_at, "Date / Time: "
+    = f.select :day, options_for_select((01..31), Time.now.day)
+    \.
+    = f.select :month, options_for_select((01..12), Time.now.month)
+    \.
+    = f.select :year, options_for_select((2017..2020), Time.now.year)
+    &nbsp;
+    = f.select :hour, options_for_select((01..24), Time.now.hour)
+    \:
+    = f.select :minute, options_for_select((00..59), Time.now.strftime('%M'))
+    \:
+    = f.select :second, options_for_select((00..59), Time.now.strftime('%S'))
+    = f.hidden_field :created_at, :value => Time.now
+    %br
     = f.label :calibrated_value, "Calibrated Value"
     = f.number_field :calibrated_value, step: 0.1, size: '6'
+    &nbsp;
     = f.label :uncalibrated_value, "Uncalibrated Value"
     = f.number_field :uncalibrated_value, step: 0.1, size: '6'
+    &nbsp;
     = f.submit "Add"

--- a/app/views/sensors/_add_sensor_reading.haml
+++ b/app/views/sensors/_add_sensor_reading.haml
@@ -1,27 +1,17 @@
 = button_tag "Add Sensor Reading manually", :id => 'unhide_sensor_reading_form', :class => "btn btn-primary"
 
-= form_tag "/sensor_readings", :id => 'sensor_reading_form', :method => "post", :remote => true do
-  %h4 Add Sensor Reading manually
-  = fields_for :sensor_reading do |f|
+#sensor_reading_form.container
+  = simple_form_for :sensor_reading, url: sensor_readings_path, remote: true do |f|
+    %h4 Add sensor reading manually
     = f.hidden_field :sensor_id, :value => @sensor.id
-    = f.label :created_at, "Date / Time: "
-    = f.select :day, options_for_select((01..31), Time.now.day)
-    \.
-    = f.select :month, options_for_select((01..12), Time.now.month)
-    \.
-    = f.select :year, options_for_select((2017..2020), Time.now.year)
-    &nbsp;
-    = f.select :hour, options_for_select((01..24), Time.now.hour)
-    \:
-    = f.select :minute, options_for_select((00..59), Time.now.strftime('%M'))
-    \:
-    = f.select :second, options_for_select((00..59), Time.now.strftime('%S'))
-    = f.hidden_field :created_at, :value => Time.now
-    %br
-    = f.label :calibrated_value, "Calibrated Value"
-    = f.number_field :calibrated_value, step: 0.1, size: '6'
-    &nbsp;
-    = f.label :uncalibrated_value, "Uncalibrated Value"
-    = f.number_field :uncalibrated_value, step: 0.1, size: '6'
-    &nbsp;
-    = f.submit "Add"
+    .form-group.row
+      = f.input :created_at, as: :datetime, label: false
+    .form-group.row
+      = f.label :calibrated_value, "Calibrated Value", class: 'col-sm-4 col-form-label col-form-label-sm'
+      .col-sm-2
+        = f.number_field :calibrated_value, step: 0.1, size: '6', class: 'form-control form-control-sm'
+      = f.label :uncalibrated_value, "Uncalibrated Value", class: 'col-sm-4 col-form-label col-form-label-sm'
+      .col-sm-2
+        = f.number_field :uncalibrated_value, step: 0.1, size: '6', class: 'form-control form-control-sm'
+    .form-group
+      = f.submit "Add", class: 'btn btn-primary'

--- a/features/sensor_readings/add_sensor_reading_manually.feature
+++ b/features/sensor_readings/add_sensor_reading_manually.feature
@@ -13,7 +13,7 @@ Feature: Add sensor reading manually
     When I visit the sensors page
     And I click on "Temperature48" to see all the sensor readings
     And I click on "Add Sensor Reading manually"
-    And I add a sensor reading for "2011-01-11 11:11:11" with a calibrated value of 25°C and an uncalibrated value of 26°C
+    And I add a sensor reading for 11-11-2017 11:11:11 with a calibrated value of 25°C and an uncalibrated value of 26°C
     And I click on "Add"
     When I visit the sensors page
     And I click on "Temperature48" to see all the sensor readings

--- a/features/sensor_readings/add_sensor_reading_manually.feature
+++ b/features/sensor_readings/add_sensor_reading_manually.feature
@@ -13,8 +13,9 @@ Feature: Add sensor reading manually
     When I visit the sensors page
     And I click on "Temperature48" to see all the sensor readings
     And I click on "Add Sensor Reading manually"
-    And I add a sensor reading for 11-11-2017 11:11:11 with a calibrated value of 25°C and an uncalibrated value of 26°C
+    And I add a sensor reading for "2017 November 11 11:11" with a calibrated value of 25°C and an uncalibrated value of 26°C
     And I click on "Add"
     When I visit the sensors page
     And I click on "Temperature48" to see all the sensor readings
-    Then this sensor should have 1 new sensor reading
+    Then I should see some generated entries in the sensor readings final table
+    And this sensor should have 1 new sensor reading

--- a/features/sensor_readings/generate_debug_sample_data.feature
+++ b/features/sensor_readings/generate_debug_sample_data.feature
@@ -15,7 +15,7 @@ Feature: Generate debug Sample Data
     And I click on "Generate debug Sample Data"
     And I choose 10 random sensor readings with a value from 3°C to 20°C
     And I click on "Generate!"
-    Then I should see some generated entries in the sensor readings table
+    Then I should see some generated entries in the sensor readings debug table
     And this sensor should have 10 new sensor readings as debug data
 
   Scenario: Distinguish debug from final Data

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -213,8 +213,8 @@ Then(/^this sensor should have (\d+) new sensor readings as debug data$/) do |qu
   expect(@sensor.sensor_readings.debug.count).to eq quantity.to_i
 end
 
-Then(/^I should see some generated entries in the sensor readings table$/) do
-  within '#sensor-readings-table-debug' do
+Then(/^I should see some generated entries in the sensor readings (debug|final) table$/) do |version|
+  within "#sensor-readings-table-#{version}" do
     expect(page).to have_css('.sensor-reading-row')
   end
 end
@@ -1223,19 +1223,12 @@ Given(/^for that diary entry we have some text components and question answers$/
   create(:text_component, report: Report.current) # this should not go into the diary entry
 end
 
-When(/^I add a sensor reading for "([^"]*)" with a calibrated value of (\d+)°C and an uncalibrated value of (\d+)°C$/) do |created_at, calibrated_value, uncalibrated_value|
-  fill_in 'Created at', with: created_at
-  fill_in 'Calibrated Value', with: calibrated_value
-  fill_in 'Uncalibrated Value', with: uncalibrated_value
-end
-
-When(/^I add a sensor reading for (\d+)\-(\d+)\-(\d+) (\d+):(\d+):(\d+) with a calibrated value of (\d+)°C and an uncalibrated value of (\d+)°C$/) do |day, month, year, hour, minute, second, calibrated_value, uncalibrated_value|
-  select day, from: 'sensor_reading_day'
-  select month, from: 'sensor_reading_month'
-  select year, from: 'sensor_reading_year'
-  select hour, from: 'sensor_reading_hour'
-  select minute, from: 'sensor_reading_minute'
-  select second, from: 'sensor_reading_second'
+When(/^I add a sensor reading for "(\d+)\ (\w+)\ (\d+) (\d+):(\d+)" with a calibrated value of (\d+)°C and an uncalibrated value of (\d+)°C$/) do |year, month, day, hour, minute, calibrated_value, uncalibrated_value|
+  select year, from: 'sensor_reading_created_at_1i'
+  select month, from: 'sensor_reading_created_at_2i'
+  select day, from: 'sensor_reading_created_at_3i'
+  select hour, from: 'sensor_reading_created_at_4i'
+  select minute, from: 'sensor_reading_created_at_5i'
   fill_in 'Calibrated Value', with: calibrated_value
   fill_in 'Uncalibrated Value', with: uncalibrated_value
 end

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1229,6 +1229,18 @@ When(/^I add a sensor reading for "([^"]*)" with a calibrated value of (\d+)°C 
   fill_in 'Uncalibrated Value', with: uncalibrated_value
 end
 
+When(/^I add a sensor reading for (\d+)\-(\d+)\-(\d+) (\d+):(\d+):(\d+) with a calibrated value of (\d+)°C and an uncalibrated value of (\d+)°C$/) do |day, month, year, hour, minute, second, calibrated_value, uncalibrated_value|
+  select day, from: 'sensor_reading_day'
+  select month, from: 'sensor_reading_month'
+  select year, from: 'sensor_reading_year'
+  select hour, from: 'sensor_reading_hour'
+  select minute, from: 'sensor_reading_minute'
+  select second, from: 'sensor_reading_second'
+  fill_in 'Calibrated Value', with: calibrated_value
+  fill_in 'Uncalibrated Value', with: uncalibrated_value
+end
+
+
 Then(/^this sensor should have (\d+) new sensor reading$/) do |quantity|
   expect(@sensor.sensor_readings.count).to eq quantity.to_i
 end


### PR DESCRIPTION
The purpose of this PR is to improve the manual input of sensor readings by offering select fields to select the date / time of the sensor reading (with current date / time preselected) and refreshing the page when an entry has been made, in order to give a visual feedback of the new record (-> show the user that entering the sensor reading worked).

At the moment the text field for date / time has been replaced by select fields with the preselected current time.

The feature that needs to be implemented yet, is the page reload when entering a new sensor reading. This is probably a bit tricky, because the form is set to remote (Ajax) and the create method for the sensor_readings expects / returns json values (https://github.com/roschaefer/story.board/blob/master/app/controllers/sensor_readings_controller.rb#L3).

---
Close #473 