### PR TITLE
Allow blank animal ids for sensors

### DIFF
--- a/app/models/sensor.rb
+++ b/app/models/sensor.rb
@@ -15,7 +15,7 @@ class Sensor < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :address, uniqueness: true
   validates :sensor_type, presence: true
-  validates :animal_id, uniqueness: { scope: :sensor_type }
+  validates :animal_id, uniqueness: { scope: :sensor_type }, :allow_blank => true
 
   def name_and_id
     "#{name} (#{id})"

--- a/app/models/sensor.rb
+++ b/app/models/sensor.rb
@@ -15,7 +15,11 @@ class Sensor < ActiveRecord::Base
   validates :name, presence: true, uniqueness: true
   validates :address, uniqueness: true
   validates :sensor_type, presence: true
-  validates :animal_id, uniqueness: { scope: :sensor_type }, :allow_blank => true
+  validates :animal_id, uniqueness: { scope: :sensor_type }, :allow_nil => true
+
+  before_validation do
+    self.animal_id = nil if self.animal_id.blank?
+  end
 
   def name_and_id
     "#{name} (#{id})"

--- a/db/migrate/20170730125054_add_unique_constraint_to_animal_id.rb
+++ b/db/migrate/20170730125054_add_unique_constraint_to_animal_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintToAnimalId < ActiveRecord::Migration[5.0]
+  def change
+    add_index :sensors, [:sensor_type_id, :animal_id], :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170724152345) do
+ActiveRecord::Schema.define(version: 20170730125054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,11 +142,11 @@ ActiveRecord::Schema.define(version: 20170724152345) do
     t.float    "max_value"
     t.float    "min_value"
     t.datetime "calibrated_at"
-    t.boolean  "smaxtec_sensor"
     t.string   "animal_id"
     t.index ["address"], name: "index_sensors_on_address", unique: true, using: :btree
     t.index ["name"], name: "index_sensors_on_name", unique: true, using: :btree
     t.index ["report_id"], name: "index_sensors_on_report_id", using: :btree
+    t.index ["sensor_type_id", "animal_id"], name: "index_sensors_on_sensor_type_id_and_animal_id", unique: true, using: :btree
     t.index ["sensor_type_id"], name: "index_sensors_on_sensor_type_id", using: :btree
   end
 
@@ -159,8 +159,8 @@ ActiveRecord::Schema.define(version: 20170724152345) do
     t.integer  "to_day"
     t.integer  "report_id"
     t.integer  "topic_id"
-    t.integer  "assignee_id"
     t.integer  "publication_status", default: 0
+    t.integer  "assignee_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "notes"

--- a/spec/models/sensor_spec.rb
+++ b/spec/models/sensor_spec.rb
@@ -20,6 +20,19 @@ describe Sensor, type: :model do
     end
   end
 
+  describe '#animal_id' do
+    context 'of two sensors with the same sensor type', issue: 500 do
+      before { create(:sensor_type, id: 11) }
+      it_behaves_like 'database unique attribute', :sensor, sensor_type_id: 11, animal_id: 123
+      context 'if #animal_id is blank' do
+        before { create(:sensor, sensor_type_id: 11, animal_id: '') }
+        subject { build(:sensor, sensor_type_id: 11, animal_id: '') }
+        it { is_expected.to be_valid }
+        it { expect{ subject.save!(validate: false) }.not_to raise_error }
+      end
+    end
+  end
+
   describe '#last_reading' do
     let(:sensor) { build(:sensor) }
     let(:first) { create(:sensor_reading, sensor: sensor, created_at: 5.seconds.ago) }


### PR DESCRIPTION
This PR solves the issue #500 "Bug Creating Sensors: Animal ID should never be required". The problem was that the Animal Id is validated to be unique for a Sensor Type together with an Animal Id. If the Animal Id is empty for one Sensor Type, there can't exist another similar Sensor Type with an empty Animal Id. 
This is solved by allowing the Animal Id to be blank (empty).

---

Close #500 