### PR TITLE
Update Capistrano to 3.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    capistrano (3.8.2)
+    capistrano (3.9.0)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)


### PR DESCRIPTION
The `Capfile` is locked to version 3.9.0 but the `Gemfile.lock` has version 3.8.2 so Capistrano tasks will not run. Update Capistrano to version 3.9.0 to fix this mismatch.