### PR TITLE
Fix context nesting in `text_component_spec.rb`

### DIFF
--- a/spec/models/text_component_spec.rb
+++ b/spec/models/text_component_spec.rb
@@ -48,30 +48,34 @@ RSpec.describe TextComponent, type: :model do
   describe '#active?' do
     let(:text_component) { create(:text_component) }
     subject { text_component.active? }
+
     context 'triggers empty' do
       it { is_expected.to be true }
+    end
 
-      context 'given one trigger' do
-        context 'active trigger' do
-          let(:text_component) { create(:text_component, triggers: [create(:trigger, :active)]) }
-          it { is_expected.to be true }
-        end
-
-        context 'inactive trigger' do
-          let(:text_component) { create(:text_component, triggers: [create(:trigger, :inactive)]) }
-          it { is_expected.to be false }
-        end
+    context 'given one trigger' do
+      context 'active trigger' do
+        let(:text_component) { create(:text_component, triggers: [create(:trigger, :active)]) }
+        it { is_expected.to be true }
       end
-      context 'given many triggers' do
-        let(:text_component) { create(:text_component, triggers: triggers) }
-        context'some are active, some are inactive' do
-          let(:triggers) { [create(:trigger, :inactive), create(:trigger, :active)] }
-          it { is_expected.to be false }
-        end
-        context'all active' do
-          let(:triggers) { create_list(:trigger, 2, :active) }
-          it { is_expected.to be true }
-        end
+
+      context 'inactive trigger' do
+        let(:text_component) { create(:text_component, triggers: [create(:trigger, :inactive)]) }
+        it { is_expected.to be false }
+      end
+    end
+
+    context 'given many triggers' do
+      let(:text_component) { create(:text_component, triggers: triggers) }
+
+      context 'some are active, some are inactive' do
+        let(:triggers) { [create(:trigger, :inactive), create(:trigger, :active)] }
+        it { is_expected.to be false }
+      end
+
+      context 'all active' do
+        let(:triggers) { create_list(:trigger, 2, :active) }
+        it { is_expected.to be true }
       end
     end
   end
@@ -79,6 +83,7 @@ RSpec.describe TextComponent, type: :model do
   describe '#priority' do
     let(:text_component) { create(:text_component) }
     subject { text_component.priority }
+
     context 'empty triggers' do
       it { is_expected.to be nil }
     end


### PR DESCRIPTION
The contexts 'given one trigger' and 'given many triggers' where nested below 'triggers empty' which is a logical contradiction. Put them on the same nesting level as 'triggers empty' instead.

Output of `rspec -f documentation` before the change:

```
TextComponent
  #active?
    triggers empty
      should equal true
      given one trigger
        active trigger
          should equal true
        inactive trigger
          should equal false
      given many triggers
        some are active, some are inactive
          should equal false
        all active
          should equal true
```

And after the change:

```
TextComponent
  #active?
    triggers empty
      should equal true
    given one trigger
      active trigger
        should equal true
      inactive trigger
        should equal false
    given many triggers
      some are active, some are inactive
        should equal false
      all active
        should equal true
```