### PR TITLE
Disallow indexing of the CMS backend in `robots.txt`

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /


### PR DESCRIPTION
The CMS backend content that is not yet behind a login shows up in search engine results.
Disallow all crawlers to index the CMS backend. This is the most restrictive setting possible.
Consider this a workaround and not a full replacement for a password protected login.