### PR TITLE
Make trigger fire if sensor reading value <= max value

### DIFF
--- a/app/models/trigger.rb
+++ b/app/models/trigger.rb
@@ -25,7 +25,7 @@ class Trigger < ActiveRecord::Base
       if reading
         active = true
         active &= (condition.from.nil? || condition.from <= reading.calibrated_value)
-        active &= (condition.to.nil? ||reading.calibrated_value < condition.to)
+        active &= (condition.to.nil? ||reading.calibrated_value <= condition.to)
         active &= (validity_period.nil? || (validity_period.hours.ago <= reading.created_at))
         active
       else

--- a/features/reports/time_travel.feature
+++ b/features/reports/time_travel.feature
@@ -11,7 +11,7 @@ Feature: Read about any point in time
       | Summer-Antenna| Temperature | °C   |
     And for my sensors I have these triggers prepared:
       | Sensor         | From | To | Trigger |
-      | Summer-Antenna | 0    | 25 | Cold    |
+      | Summer-Antenna | 0    | 24 | Cold    |
       | Summer-Antenna | 25   | 40 | Hot     |
     And these are the connections between text components and triggers:
       | Trigger | Text component                          |

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -80,13 +80,9 @@ RSpec.describe Report, type: :model do
           create(:sensor_reading, sensor: sensor, calibrated_value: 10)
         end
 
-        describe'then the report contains only one active text component' do
-          it 'ie. the upper component' do
-            expect(subject).to contain_exactly(upper_component)
-          end
-
-          it 'and not the lower component' do
-            expect(subject).not_to contain_exactly(lower_component)
+        describe'then the report contains both active text components' do
+          it 'ie. the lower component and the upper component' do
+            expect(subject).to contain_exactly(upper_component, lower_component)
           end
         end
       end


### PR DESCRIPTION
This is the proposed fix for the "TRIGGER for ALERTS NOT WORKING" problem as stated in #627.

Please mind that this changes the behavior of consecutive trigger values, as @roschaefer pointed out. This could lead to serious side effects, if there are triggers who have consecutive values e.g. trigger1 10-20, trigger2 20-30. When the value of 20 is hit, both triggers will now fire.

---

Close #627 