### PR TITLE
Setup page caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'devise'
 # Image upload to Amazon S3 Storage Cloud
 gem 'paperclip'
 gem 'aws-sdk', '~> 2.3'
+gem "actionpack-page_caching"
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
       rack-test (~> 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionpack-page_caching (1.1.0)
+      actionpack (>= 4.0.0, < 6)
     actionview (5.0.5)
       activesupport (= 5.0.5)
       builder (~> 3.1)
@@ -390,6 +392,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-page_caching
   aws-sdk (~> 2.3)
   bootstrap!
   capistrano

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -3,6 +3,9 @@ class DiaryEntriesController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
   include CommonFilters
 
+  self.page_cache_directory = -> { Rails.root.join('public', request.domain) }
+  caches_page :show
+
   def index
     from_and_to_params_are_dates(filter_params) or return
     @diary_entries = DiaryEntry.where(report: @report).order(:moment)

--- a/app/controllers/diary_entries_controller.rb
+++ b/app/controllers/diary_entries_controller.rb
@@ -3,7 +3,7 @@ class DiaryEntriesController < ApplicationController
   before_action :authenticate_user!, except: %i[index show]
   include CommonFilters
 
-  self.page_cache_directory = -> { Rails.root.join('public', request.domain) }
+  self.page_cache_directory = -> { Rails.root.join('public') }
   caches_page :show
 
   def index

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,6 @@ Rails.application.configure do
     :secret_access_key => ENV.fetch('AWS_SECRET_ACCESS_KEY'),
     :s3_region => 'eu-central-1'
   }
+
+  config.action_controller.page_cache_directory = Rails.root.join('public/page_cache')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,5 +89,5 @@ Rails.application.configure do
     :s3_region => 'eu-central-1'
   }
 
-  config.action_controller.page_cache_directory = Rails.root.join('public/page_cache')
+  config.action_controller.page_cache_directory = Rails.root.join('public')
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -18,6 +18,10 @@ end
 every 15.minutes do
   rake 'smaxtec_api:update_sensors'
 end
+
+every 1.minutes do
+  rake 'cache:delete'
+end
 #
 # every 4.days do
 #   runner "AnotherModel.prune_old_records"

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :cache do
+  desc 'Delete cached files'
+  task delete: :environment do
+    FileUtils.rm_rf(Rails.root.join('public', 'reports'))
+  end
+end


### PR DESCRIPTION
close #621 

To give a little context here: Our app already servers static files, [which is discouraged by the way](http://guides.rubyonrails.org/configuring.html).


> config.public_file_server.enabled configures Rails to serve static files from the public directory. This option defaults to true, but in the production environment it is set to false because the server software (e.g. NGINX or Apache) used to run the application should serve static files instead. If you are running or testing your app in production mode using WEBrick (it is not recommended to use WEBrick in production) set the option to true. Otherwise, you won't be able to use page caching and request for files that exist under the public directory.

 The gem will now create cached files directly into the `public` folder, since we have the `show` route of `diary_entries` below `/reports/`, all cached files should end up in `public/reports`. We now delete every minute (that is the highest possible frequency with `cron`) this particular folder.