### PR TITLE
638 fix text component selecting report

### DIFF
--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -14,7 +14,7 @@
 
           .row
             .col
-              = f.association :report, selected: @report.id, input_html: {'data-choices': true}
+              = f.association :report, selected: @text_component.report.id, input_html: {'data-choices': true}
             .col
               = f.association :topic, label_method: :display_name, include_blank: 'No topic', input_html: {'data-choices': true}
 

--- a/app/views/text_components/_form.html.haml
+++ b/app/views/text_components/_form.html.haml
@@ -14,7 +14,7 @@
 
           .row
             .col
-              = f.association :report, selected: @text_component.report.id, input_html: {'data-choices': true}
+              = f.association :report, selected: @text_component.report_id, input_html: {'data-choices': true}
             .col
               = f.association :topic, label_method: :display_name, include_blank: 'No topic', input_html: {'data-choices': true}
 


### PR DESCRIPTION
Fix text component showing the wrong selected report. Before it showed the globally selected report (@report.id), now it shows the report selected for the text component (@text_component.report_id).

---

Close #638