### PR TITLE
606 show timeframe

### DIFF
--- a/app/assets/stylesheets/components/_item-table.scss
+++ b/app/assets/stylesheets/components/_item-table.scss
@@ -26,6 +26,10 @@
     line-height: 1rem * $line-height-base;
 }
 
+.item-table__meta {
+    white-space: nowrap;
+}
+
 .item-table__actions {
     white-space: nowrap;
 

--- a/app/controllers/text_components_controller.rb
+++ b/app/controllers/text_components_controller.rb
@@ -81,7 +81,7 @@ class TextComponentsController < ApplicationController
 
       filter_text_components
 
-      @trigger_groups = @text_components.order('from_day').group_by(&:trigger_ids)
+      @trigger_groups = @text_components.order('from_day, from_hour').group_by(&:trigger_ids)
 
       @trigger_groups = @trigger_groups.map do |trigger_ids, components|
         [Trigger.find(trigger_ids), components]

--- a/app/views/text_components/_table.html.haml
+++ b/app/views/text_components/_table.html.haml
@@ -1,11 +1,10 @@
 %table.table.item-table
   %thead.thead-default
     %tr
-      %th{width: '40%'} Trigger
+      %th{width: '30%'} Trigger
       %th
-      %th{width: '40%'} Headline
-      %th Start
-      %th End
+      %th{width: '50%'} Headline
+      %th.text-center Days/Time
       %th
   %tbody
     - @trigger_groups.each do |triggers, text_components|

--- a/app/views/text_components/_table_row.html.haml
+++ b/app/views/text_components/_table_row.html.haml
@@ -1,19 +1,19 @@
-%td.item-table__channels{class: "text-#{text_component.css_status_class}"}
+%td.item-table__channels.align-middle{class: "text-#{text_component.css_status_class}"}
   %span{data: {toggle: 'tooltip'}, title: "#{text_component.channels.map{|c| c.name.humanize}.join(', ')} / #{text_component.publication_status.humanize}"}
     - if(text_component.channel_icons.count > 1)
       %span{class: ['fa', 'fa-ellipsis-h']}
     - else
       %span{class: ['fa', text_component.channel_icons.first]}
 
-%td
-  .item-table__title
-    = text_component.heading
+%td.align-middle
+  = text_component.heading
 
-%td= text_component.from_day
+%td.small.text-center.align-middle.item-table__time
+  = "#{text_component.from_day} – #{text_component.to_day}"
+  %br
+  = TextComponent::TIME_FRAMES.find{ |name,value| value == text_component.timeframe }.first.gsub(/\(.*\)\s*/, '')
 
-%td= text_component.to_day
-
-%td.item-table__actions
+%td.item-table__actions.align-middle
   = link_to edit_report_text_component_path(@report, text_component), {class: 'item-table__action--edit'} do
     %i.fa.fa-pencil{title: 'Edit Text Component', data: {toggle: 'tooltip'}}
   = link_to report_text_component_path(@report, text_component), {method: :delete, class: 'item-table__action--destroy', data: {confirm: 'Are you sure?'}} do

--- a/app/views/text_components/_table_row.html.haml
+++ b/app/views/text_components/_table_row.html.haml
@@ -8,7 +8,7 @@
 %td.align-middle
   = text_component.heading
 
-%td.small.text-center.align-middle.item-table__time
+%td.small.text-center.align-middle.item-table__meta
   = "#{text_component.from_day} – #{text_component.to_day}"
   %br
   = TextComponent::TIME_FRAMES.find{ |name,value| value == text_component.timeframe }.first.gsub(/\(.*\)\s*/, '')

--- a/spec/views/text_components/index.html.haml_spec.rb
+++ b/spec/views/text_components/index.html.haml_spec.rb
@@ -60,8 +60,7 @@ RSpec.describe "text_components/index", type: :view do
 
     it "shows from and to days" do
       render
-      assert_select ".item-table__item td", :text => 1.to_s, :count => 2
-      assert_select ".item-table__item td", :text => 2.to_s, :count => 2
+      assert_select ".item-table__item td", :text => "1 – 2\n\nalways", :count => 2
     end
 
     it "indicates the publication status" do


### PR DESCRIPTION
The timeframe will now be displayed in the text components listing as well.

@matthib: I know this [regex replacement](https://github.com/roschaefer/story.board/blob/606_show_timeframe/app/views/text_components/_table_row.html.haml#L14) is quite dirty, I didn’t want to refactor the[ part of the model](https://github.com/roschaefer/story.board/blob/606_show_timeframe/app/models/text_component.rb#L2-L9) where those labels are generated…

@drjakob: Unfortunately I didn’t find a good way to indicate the timeframe using icons or anything else, but I think simple text is actually a good and unambigous solution in this case.

<img width="1440" alt="bildschirmfoto 2017-09-02 um 17 05 54" src="https://user-images.githubusercontent.com/1512805/29996579-8363f670-9001-11e7-8590-6ba38c4a42b0.png">

close #606 