### PR TITLE
644 Remove back button in Report#show

### DIFF
--- a/app/views/reports/show.html.haml
+++ b/app/views/reports/show.html.haml
@@ -14,5 +14,3 @@
 = render 'variables'
 
 = link_to 'Edit', edit_report_path(@report), :class => "btn btn-primary"
-
-= link_to 'Back', reports_path, :class => "btn btn-secondary"


### PR DESCRIPTION
The back button is actually pretty useless in this view as we don’t have an index view for reports and I can’t think of a sensible target for that link. I’ve removed it to avoid confusion. Please merge if you’re okay with this solution.