### PR TITLE
Add new priorities totally_boring and always_on_top

### DIFF
--- a/app/models/trigger.rb
+++ b/app/models/trigger.rb
@@ -9,7 +9,7 @@ class Trigger < ActiveRecord::Base
   validates :priority, presence: true
   accepts_nested_attributes_for :conditions, reject_if: :all_blank, allow_destroy: true
 
-  enum priority: { very_low: -1, low: 0, medium: 1, high: 2, urgent: 3}
+  enum priority: { totally_boring: -2 ,very_low: -1, low: 0, medium: 1, high: 2, urgent: 3, always_on_top: 4}
 
   def self.default_scope
     order('LOWER("triggers"."name")')

--- a/spec/models/diary_entry/html_output_spec.rb
+++ b/spec/models/diary_entry/html_output_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe DiaryEntry, type: :model do
         context 'every text component has a trigger with a different priority' do
           let!(:text_components) do
             [
-              create(:text_component, report: report, heading: 'Text component 1', triggers: [create(:trigger, priority: :high)]),
-              create(:text_component, report: report, heading: 'Text component 2', triggers: [create(:trigger, priority: :medium)]),
-              create(:text_component, report: report, heading: 'Text component 3', triggers: [create(:trigger, priority: :low)]),
+              create(:text_component, report: report, heading: 'Text component 1', triggers: [create(:trigger, priority: :always_on_top)]),
+              create(:text_component, report: report, heading: 'Text component 2', triggers: [create(:trigger, priority: :high)]),
+              create(:text_component, report: report, heading: 'Text component 3', triggers: [create(:trigger, priority: :medium)]),
+              create(:text_component, report: report, heading: 'Text component 4', triggers: [create(:trigger, priority: :low)]),
+              create(:text_component, report: report, heading: 'Text component 5', triggers: [create(:trigger, priority: :totally_boring)]),
             ]
           end
           it { is_expected.to eq 'Text component 1'}

--- a/spec/models/text_component_spec.rb
+++ b/spec/models/text_component_spec.rb
@@ -142,10 +142,11 @@ RSpec.describe TextComponent, type: :model do
       before do
         create(:trigger, text_components: [text_component], priority: :medium)
         create(:trigger, text_components: [text_component], priority: :high)
+        create(:trigger, text_components: [text_component], priority: :always_on_top)
       end
 
       it 'is the highest priority' do
-        is_expected.to eq 'high'
+        is_expected.to eq 'always_on_top'
       end
     end
   end

--- a/spec/requests/diary_entries_spec.rb
+++ b/spec/requests/diary_entries_spec.rb
@@ -18,14 +18,16 @@ RSpec.describe "DiaryEntries", type: :request do
 
       describe 'priorities' do
         it 'define order of text components' do
+          create(:text_component, report: report, heading: 'Totally boring component 1',  triggers: create_list(:trigger, 1, priority: :totally_boring))
           create(:text_component, report: report, heading: 'Low priority component 1',  triggers: create_list(:trigger, 1, priority: :low))
           create(:text_component, report: report, heading: 'Low priority component 2',  triggers: create_list(:trigger, 1, priority: :low))
           create(:text_component, report: report, heading: 'Medium priority component', triggers: create_list(:trigger, 1, priority: :medium))
           create(:text_component, report: report, heading: 'Low priority component 3',  triggers: create_list(:trigger, 1, priority: :low))
           create(:text_component, report: report, heading: 'High priority component',   triggers: create_list(:trigger, 1, priority: :high))
+          create(:text_component, report: report, heading: 'Always on top priority component',   triggers: create_list(:trigger, 1, priority: :always_on_top))
           action
-          expect(js['text_components'][0]['heading']).to eq 'High priority component'
-          expect(js['text_components'][1]['heading']).to eq 'Medium priority component'
+          expect(js['text_components'][0]['heading']).to eq 'Always on top priority component'
+          expect(js['text_components'][1]['heading']).to eq 'High priority component'
           expect(js['text_components'].count).to eq 3
         end
       end

--- a/spec/text/sorter_spec.rb
+++ b/spec/text/sorter_spec.rb
@@ -7,13 +7,15 @@ RSpec.describe Text::Sorter do
     let(:opts) { {} }
 
     context 'several text components with different priorities' do
-      let(:expected_result) { [text_components[2], text_components[0], text_components[1]] }
+      let(:expected_result) { [text_components[3], text_components[2], text_components[0], text_components[1]] }
 
       let(:text_components) do
         [
           create(:text_component, heading: 'Text component Medium', triggers: [create(:trigger, priority: :medium)]),
           create(:text_component, heading: 'Text component Low', triggers: [create(:trigger, priority: :low)]),
           create(:text_component, heading: 'Text component High', triggers: [create(:trigger, priority: :high)]),
+          create(:text_component, heading: 'Text component High', triggers: [create(:trigger, priority: :always_on_top)]),
+
         ]
       end
 


### PR DESCRIPTION
I added two new priorities at the end of the list: totally_boring and always_on_top. Technically always_on_top has just the highest priority, so if there are two always_on_top priorities, just one can be "always on top". But as @drjakob stated in the original issue, this priority is used rarely and exclusively, so there is not much of a conflict.

---

Close #642 