### PR TITLE
Fix #639

### DIFF
--- a/app/models/trigger.rb
+++ b/app/models/trigger.rb
@@ -26,7 +26,7 @@ class Trigger < ActiveRecord::Base
         active = true
         active &= (condition.from.nil? || condition.from <= reading.calibrated_value)
         active &= (condition.to.nil? ||reading.calibrated_value <= condition.to)
-        active &= (validity_period.nil? || (validity_period.hours.ago <= reading.created_at))
+        active &= (validity_period.nil? || (diary_entry.moment - validity_period.hours <= reading.created_at))
         active
       else
         false

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -7,16 +7,31 @@ describe Trigger, type: :model do
   context 'given a sensor reading' do
     let(:diary_entry) { DiaryEntry.new(report: trigger.report, moment: Time.zone.now) }
     let(:trigger) { create(:trigger, :with_a_sensor_reading, params) }
+
     describe '#validity_period' do
       let(:params) { { validity_period: 3 } }
+
       it { trigger.active?(diary_entry) }
+
       context 'some hours later' do
-        it 'no longer relevant' do
-          expect(trigger.active?(diary_entry)).to be_truthy
+        let(:future_diary_entry) do
           Timecop.travel(4.hours.from_now) do
-            expect(trigger.active?(diary_entry)).to be_falsy
+            future_diary_entry = DiaryEntry.new(report: trigger.report, moment: Time.zone.now)
           end
         end
+
+        it 'is no longer relevant' do
+          Timecop.travel(4.hours.from_now) do
+            expect(trigger.active?(future_diary_entry)).to be_falsy
+          end
+        end
+
+        it 'is still active for past diary entries' do
+          Timecop.travel(4.hours.from_now) do
+            expect(trigger.active?(diary_entry)).to be_truthy
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
For details, see the comments for issue #639.

By the way: I was a bit surprised the tests in `reports/time_travel.feature` did not fail. Maybe we should extend these tests to use the validity period as well.

close #639 