### PR TITLE
Add big & small thumbnail image url to text component json

### DIFF
--- a/app/models/text_component.rb
+++ b/app/models/text_component.rb
@@ -17,6 +17,14 @@ class TextComponent < ActiveRecord::Base
     big: '1000>',
   }
 
+  def image_url_big
+    return image.url(:big)
+  end
+
+  def image_url_small
+    return image.url(:small)
+  end
+
   validates :heading, :report, presence: true
   validates :from_hour, inclusion: { in: 0..23 }, allow_blank: true
   validates :to_hour, inclusion: { in: 0..23 }, allow_blank: true

--- a/app/views/text_components/_text_component.json.jbuilder
+++ b/app/views/text_components/_text_component.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! text_component, :id, :heading, :introduction, :main_part, :closing, :from_day, :to_day, :image_url, :image_alt
+json.extract! text_component, :id, :heading, :introduction, :main_part, :closing, :from_day, :to_day, :image_url, :image_url_big, :image_url_small, :image_alt
 json.question_answers do
   json.array!(text_component.question_answers, partial: 'question_answers/question_answer', as: :question_answer)
 end

--- a/features/diary_entries/markup.feature
+++ b/features/diary_entries/markup.feature
@@ -38,6 +38,8 @@ Feature: Render markup for frontend
           "to_day": null,
           "question_answers": [ ],
           "image_url": "/images/original/missing.png",
+          "image_url_big": "/images/big/missing.png",
+          "image_url_small": "/images/small/missing.png",
           "image_alt": null,
           "question_answers": [
             {

--- a/features/diary_entries/show.feature
+++ b/features/diary_entries/show.feature
@@ -29,6 +29,8 @@ Feature: Generate sensorstory as JSON for frontend
           "from_day": null,
           "to_day": null,
           "image_url": "/images/original/missing.png",
+          "image_url_big": "/images/big/missing.png",
+          "image_url_small": "/images/small/missing.png",
           "image_alt": null,
           "question_answers": [
             {
@@ -55,6 +57,8 @@ Feature: Generate sensorstory as JSON for frontend
           "from_day": null,
           "to_day": null,
           "image_url": "/images/original/missing.png",
+          "image_url_big": "/images/big/missing.png",
+          "image_url_small": "/images/small/missing.png",
           "image_alt": null,
           "question_answers": [
 


### PR DESCRIPTION
The paperclip gem generates thumbnails for the images in the text component: a big one with a width of 1000px and a small one with a width of 620px. I added the url to these thumbnails in the json that is sent to the frontend. 
The original image can still be accessed via image_url, the big thumbnail via image_url_big and the small one via image_url_small.