### PR TITLE
Add file size validation for image upload

### DIFF
--- a/app/models/text_component.rb
+++ b/app/models/text_component.rb
@@ -43,7 +43,9 @@ class TextComponent < ActiveRecord::Base
 
   validates :channels, presence: true
   # Validate the attached image is image/jpg, image/png, etc
-  validates_attachment :image, content_type: { content_type: /\Aimage\/.*\z/ }
+  validates_attachment :image,
+    content_type: { content_type: /\Aimage\/.*\z/ },
+    size: { in: 0..20.megabytes }
 
   delegate :name, to: :topic, prefix: true, allow_nil: true
   delegate :name, to: :assignee, prefix: true, allow_nil: true


### PR DESCRIPTION
This adds a file size validation for the text component image upload in order to prevent the reporters from uploading images that are too big for the server too handle.
The image maximum file size is set to 20 MB with this commit.