### PR TITLE
Show image icon in text component overview if text component has exis…

### DIFF
--- a/app/views/text_components/_table_text_component.html.haml
+++ b/app/views/text_components/_table_text_component.html.haml
@@ -1,6 +1,9 @@
 %td.item-table__channels.align-middle{class: text_component.table_highlight_class}
   %span{class: "text-#{text_component.status_class}", data: {toggle: 'tooltip'}, title: text_component.table_status_text}
     %span{class: ['fa', text_component.table_channel_icon]}
+  - if text_component&.image&.exists?
+    %span{class: "text-#{text_component.status_class}", data: {toggle: 'tooltip'}, title: 'Image uploaded'}
+      %span{class: ['fa fa-image']}
 
 %td.align-middle{class: text_component.table_highlight_class}
   = link_to(text_component.heading, report_text_component_path(@report, text_component), {class: 'item-table__link'})


### PR DESCRIPTION
Show image icon in text component overview if text component has existing image. The image icon is shown next to the status icon of the text component (draft, published, chatbot ...) if an image exists. It can be considered to move the image icon into its own column.



---

Close #705 